### PR TITLE
Fix "url not defined" error in testcenter-validation.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,9 @@
     "node-fetch": "^2.6.1",
     "nunjucks": "^3.1.6",
     "request": "^2.88.0"
+  },
+  "engines": {
+    "node": ">=12",
+    "npm": ">=7"
   }
 }

--- a/validation/.jshintrc
+++ b/validation/.jshintrc
@@ -1,0 +1,6 @@
+{
+    "node": true,
+    "globals": {
+    	"URL": true
+    }
+}


### PR DESCRIPTION
The following pull request contain the relevant changes and discussion which led to using `URL` and specifying a `node` and a `npm` version.
- https://github.com/wo-ist-markt/wo-ist-markt.github.io/pull/360
- https://github.com/wo-ist-markt/wo-ist-markt.github.io/pull/361