### PR TITLE
Fix validation error by sanitizing opening_hours property.

### DIFF
--- a/cities/berlin.json
+++ b/cities/berlin.json
@@ -19,7 +19,7 @@
         "location": "Luckenwalder Str. 6b 10963  Berlin",
         "telephone": null,
         "details_url": "https://15minutentest.de",
-        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; Sa 07:00 - 18:00; Su 07:00 - 18:00; ",
+        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; Sa 07:00 - 18:00; Su 07:00 - 18:00",
         "title": "030 CoronaTestStation",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -41,7 +41,7 @@
         "location": "Chausseestr. 52 10115 Berlin",
         "telephone": null,
         "details_url": "https://www.testcenter.berlin/",
-        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00; ",
+        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00",
         "title": "10 Minuten-Schnelltest | Testcenter Berlin Mitte",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -63,7 +63,7 @@
         "location": "Hauptstr. 30 10827 Berlin",
         "telephone": null,
         "details_url": "https://www.testcenter.berlin/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "10 Minuten-Schnelltest | Testcenter Havanna Schöneberg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -85,7 +85,7 @@
         "location": "Stresemannstraße 110 10963 Berlin",
         "telephone": null,
         "details_url": "https://100test.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00",
         "title": "100test.de Stresemannstraße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -107,7 +107,7 @@
         "location": "Novalisstraße 11 10115 Berlin",
         "telephone": null,
         "details_url": "https://www.stadtapotheke-berlin.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 17:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 17:00",
         "title": "10115 Teststelle -Novalisstraße",
         "hints": [
           "PCR-Nachtestung: ja",
@@ -129,7 +129,7 @@
         "location": "Leipziger Pl. 12 10117 Berlin",
         "telephone": null,
         "details_url": "http://asb-coronatest.de/mall",
-        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; ",
+        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00",
         "title": "10117 ASB-Teststation in der Mall of Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -151,7 +151,7 @@
         "location": "Ziegelstraße 30 10117 Berlin",
         "telephone": null,
         "details_url": "https://www.coronatest.de",
-        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 06:00 - 20:00; ",
+        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 06:00 - 20:00",
         "title": "10117 Coronatest.de S/U Friedrichstraße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -173,7 +173,7 @@
         "location": "Mohrenstraße 30 10117 Berlin",
         "telephone": null,
         "details_url": "https://www.stadtapotheke-berlin.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 10:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 10:00 - 14:00",
         "title": "10117 Testzentrum Gendarmenmarkt",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -195,7 +195,7 @@
         "location": "Rosenthaler Str. 9 10119 Berlin",
         "telephone": null,
         "details_url": "https://www.stadtapotheke-berlin.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 10:00 - 18:00",
         "title": "10119 Teststelle Rosenthaler Platz",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -217,7 +217,7 @@
         "location": "Panoramastraße 1A 10178 Berlin",
         "telephone": null,
         "details_url": "http://asb-coronatest.de/memu",
-        "opening_hours": "Mo 12:00 - 18:00; Tu 12:00 - 18:00; We 12:00 - 18:00; Th 12:00 - 18:00; Fr 12:00 - 18:00; Sa 12:00 - 18:00; Su 12:00 - 18:00; ",
+        "opening_hours": "Mo 12:00 - 18:00; Tu 12:00 - 18:00; We 12:00 - 18:00; Th 12:00 - 18:00; Fr 12:00 - 18:00; Sa 12:00 - 18:00; Su 12:00 - 18:00",
         "title": "10178 ASB-Teststation Mitte am Alexanderplatz",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -239,7 +239,7 @@
         "location": "Koppenstr. 3 10243 Berlin",
         "telephone": null,
         "details_url": "https://coronatest.de/buchen/",
-        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "10243 Coronatest.de S/U Ostbahnhof",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -261,7 +261,7 @@
         "location": "Revaler Str. 99 10245 Berlin",
         "telephone": null,
         "details_url": "https://www.coronatest.de",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "10245 Coronatest.de S/U Warschauer Str.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -283,7 +283,7 @@
         "location": "Am Tierpark 39, (Haupteingang Bärenfester, U-Bahn Am Tierpark) 10319  Berlin",
         "telephone": null,
         "details_url": "https://www.stadtapotheke-berlin.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "10319 Teststation Tierpark (Haupteingang Z)",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -305,7 +305,7 @@
         "location": "Schönhauser Allee 36 10435 Berlin",
         "telephone": null,
         "details_url": "https://www.coronazentrum-kulturbrauerei.de/",
-        "opening_hours": "Mo 07:00 - 21:00; Tu 07:00 - 21:00; We 07:00 - 21:00; Th 07:00 - 21:00; Fr 07:00 - 21:00; Sa 07:00 - 21:00; Su 07:00 - 21:00; ",
+        "opening_hours": "Mo 07:00 - 21:00; Tu 07:00 - 21:00; We 07:00 - 21:00; Th 07:00 - 21:00; Fr 07:00 - 21:00; Sa 07:00 - 21:00; Su 07:00 - 21:00",
         "title": "10435 Coronazentrum Kulturbrauerei",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -327,7 +327,7 @@
         "location": "Nollendorfpl. 5 10777 Berlin",
         "telephone": null,
         "details_url": "https://www.stadtapotheke-berlin.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 09:00 - 18:00",
         "title": "10777 Testzentrum im Metropol",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -349,7 +349,7 @@
         "location": "Budapester Str. 30a 10787  Berlin",
         "telephone": null,
         "details_url": "https://www.stadtapotheke-berlin.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00",
         "title": "10787 Teststation Zoo (Elefantentor)",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -371,7 +371,7 @@
         "location": "Breitscheidplatz 1 10789 Berlin",
         "telephone": null,
         "details_url": "https://www.coronatest.de",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "10789 Coronatest.de S/U Zoologischer Garten",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -393,7 +393,7 @@
         "location": "Gneisenaustr. 40 10961 Berlin",
         "telephone": null,
         "details_url": "http://asb-coronatest.de/gnei",
-        "opening_hours": "Mo 12:00 - 20:00; Tu 12:00 - 20:00; We 12:00 - 20:00; Th 12:00 - 20:00; Fr 12:00 - 20:00; Sa 12:00 - 20:00; Su 12:00 - 20:00; ",
+        "opening_hours": "Mo 12:00 - 20:00; Tu 12:00 - 20:00; We 12:00 - 20:00; Th 12:00 - 20:00; Fr 12:00 - 20:00; Sa 12:00 - 20:00; Su 12:00 - 20:00",
         "title": "10961 ASB-Teststation Kreuzberg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -415,7 +415,7 @@
         "location": "Charlottenstraße 2 10969 Berlin",
         "telephone": null,
         "details_url": "https://www.coronazentrum-kochstrasse.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00",
         "title": "10969 Coronazentrum U-Bhf. Kochstraße",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -437,7 +437,7 @@
         "location": " Muskauer Str.15 10997 Berlin",
         "telephone": null,
         "details_url": "https://www.corona-schnelltest-kreuzberg.de/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 10:00 - 15:00; Su 10:00 - 15:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 10:00 - 15:00; Su 10:00 - 15:00",
         "title": "10997 Testzentrum Kreuzberg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -459,7 +459,7 @@
         "location": "Alt-Tempelhof 17-19 12099 Berlin",
         "telephone": null,
         "details_url": "https://coronatest.de/buchen",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "12099 Coronatest.de U Alt-Tempelhof",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -481,7 +481,7 @@
         "location": "General-Pape-Str. 1 12101 Berlin",
         "telephone": null,
         "details_url": "https://coronatest.de/buchen/",
-        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "12101 Coronatest.de S/U Südkreuz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -503,7 +503,7 @@
         "location": "Schloßstrasse 10 12163 Berlin",
         "telephone": null,
         "details_url": "https://coronatest-boulevard-berlin.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 09:00 - 20:00; Su 10:00 - 15:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 09:00 - 20:00; Su 10:00 - 15:00",
         "title": "12163 Coronatestzentrum im Boulevard Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -525,7 +525,7 @@
         "location": "Brückenstrasse 1 10179 Berlin",
         "telephone": null,
         "details_url": "http://www.123test-kitkat.club",
-        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 09:00 - 16:00; ",
+        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 09:00 - 16:00",
         "title": "123test KitKatClub",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -547,7 +547,7 @@
         "location": "Adlergestell 143 12439  Berlin",
         "telephone": null,
         "details_url": "https://coronatest.de/",
-        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "12439 Coronatest.de S Johannisthal",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -569,7 +569,7 @@
         "location": "Edisonstr. 63 12459  Berlin",
         "telephone": null,
         "details_url": "https://www.stadtapotheke-berlin.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 18:00",
         "title": "12459 Teststelle WHITE Spreelounge",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -591,7 +591,7 @@
         "location": "Alt-Mahlsdorf 85 Direkt an der B1 B5 12623 Berlin",
         "telephone": null,
         "details_url": "https://www.teststation-mahlsdorf.de/",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; Su 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; Su 10:00 - 19:00",
         "title": "12623 Coronateststation Mahlsdorf an der B1/B5",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -613,7 +613,7 @@
         "location": "Berliner Str. 119, (Milchmanns) 13187  Berlin",
         "telephone": null,
         "details_url": "https://www.stadtapotheke-berlin.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 10:00 - 16:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 10:00 - 16:00",
         "title": "13187 Teststation Berliner Straße",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -635,7 +635,7 @@
         "location": "Lindower Str. 18   13347 Berlin",
         "telephone": null,
         "details_url": "https://schnelltestberlin.de/buergertest-wedding/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "13347 Testzentrum S-Bhf Wedding | Schnelltestberlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -657,7 +657,7 @@
         "location": "Soorstraße 14057 Berlin",
         "telephone": null,
         "details_url": "https://coronatest.de/buchen/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "14057 Coronatest.de ZOB",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -679,7 +679,7 @@
         "location": "Breite Str. 24 14199 Berlin",
         "telephone": null,
         "details_url": "https://www.testcenter.berlin/",
-        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00; ",
+        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00",
         "title": "15 Minuten-Schnelltest | Corona Testzentrum Schmargendorf",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -701,7 +701,7 @@
         "location": "Joachim-Karnatz-Allee 47 10557 Berlin",
         "telephone": null,
         "details_url": "http://www.15minutentest.de/berlin/",
-        "opening_hours": "Mo 08:30 - 15:30; Tu 08:30 - 15:30; We 08:30 - 15:30; Th 08:30 - 15:30; Fr 08:30 - 15:30; ",
+        "opening_hours": "Mo 08:30 - 15:30; Tu 08:30 - 15:30; We 08:30 - 15:30; Th 08:30 - 15:30; Fr 08:30 - 15:30",
         "title": "15-Minuten-Coronatest-Berlin-Mitte",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -723,7 +723,7 @@
         "location": "Ritterstraße 24-27 10969 Berlin",
         "telephone": null,
         "details_url": "https://15minutentest.de/kostenloser-buergertest/",
-        "opening_hours": "Mo 07:00 - 12:00,15:00 - 20:00; Tu 07:00 - 12:00,15:00 - 20:00; We 07:00 - 12:00,15:00 - 20:00; Th 07:00 - 12:00,15:00 - 20:00; Fr 07:00 - 12:00,15:00 - 20:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 07:00 - 12:00,15:00 - 20:00; Tu 07:00 - 12:00,15:00 - 20:00; We 07:00 - 12:00,15:00 - 20:00; Th 07:00 - 12:00,15:00 - 20:00; Fr 07:00 - 12:00,15:00 - 20:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "15Minutentest-Berlin-Kreuzberg",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -745,7 +745,7 @@
         "location": "Köpenicker Str. 18-20 10997 Berlin",
         "telephone": null,
         "details_url": "https://15minutentest.de/kostenloser-buergertest/",
-        "opening_hours": "Mo 07:00 - 13:00,14:00 - 19:00; Tu 07:00 - 13:00,14:00 - 19:00; We 07:00 - 13:00,14:00 - 19:00; Th 07:00 - 13:00,14:00 - 19:00; Fr 07:00 - 13:00,14:00 - 19:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 07:00 - 13:00,14:00 - 19:00; Tu 07:00 - 13:00,14:00 - 19:00; We 07:00 - 13:00,14:00 - 19:00; Th 07:00 - 13:00,14:00 - 19:00; Fr 07:00 - 13:00,14:00 - 19:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "15Minutentest.de / Wrangelkiez",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -767,7 +767,7 @@
         "location": "Adlergestell 303 12489 Berlin",
         "telephone": null,
         "details_url": "https://www.365pluspm.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "365+ Adlershof",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -789,7 +789,7 @@
         "location": "Buchberger Str. 5 10365  Berlin",
         "telephone": null,
         "details_url": "https://www.365pluspm.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "365+ Lichtenberg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -811,7 +811,7 @@
         "location": "Naumburger Straße 33 12057  Berlin",
         "telephone": null,
         "details_url": "https://www.365pluspm.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "365+ Neukölln",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -833,7 +833,7 @@
         "location": "Blankenburger Str. 86-92 13158 Berlin",
         "telephone": null,
         "details_url": "https://www.365pluspm.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "365+ Pankow",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -855,7 +855,7 @@
         "location": "Ostseestr. 107-111 10409  Berlin",
         "telephone": null,
         "details_url": "https://www.365pluspm.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "365+ Prenzlauer Berg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -877,7 +877,7 @@
         "location": "Waidmannsluster Damm 190 13469 Berlin",
         "telephone": null,
         "details_url": "https://www.365pluspm.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "365+ Reinickendorf",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -899,7 +899,7 @@
         "location": "Wilhelmstr. 8 13595 Berlin",
         "telephone": null,
         "details_url": "https://www.365pluspm.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "365+ Spandau01",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -921,7 +921,7 @@
         "location": "Nonnendammallee 121 13629 Berlin",
         "telephone": null,
         "details_url": "https://www.365pluspm.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "365+ Spandau02",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -943,7 +943,7 @@
         "location": "Goerzallee 189-223 14167 Berlin",
         "telephone": null,
         "details_url": "https://www.365pluspm.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "365+ Steglitz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -965,7 +965,7 @@
         "location": "Demminer Str. 31 13355 Berlin",
         "telephone": null,
         "details_url": "https://www.365pluspm.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "365+ Wedding",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -987,7 +987,7 @@
         "location": "Tempelhofer Damm 228 12099 Berlin",
         "telephone": null,
         "details_url": "https://connect.shore.com/bookings/3xhno/services?locale=de&origin=standalone",
-        "opening_hours": "Mo 08:30 - 12:00,14:00 - 18:00; Tu 08:30 - 12:00,14:00 - 18:00; We 08:30 - 12:00,14:00 - 18:00; Th 08:30 - 12:00,14:00 - 18:00; Fr 08:30 - 12:00,14:00 - 18:00; Sa 08:30 - 12:00,14:00 - 18:00; ",
+        "opening_hours": "Mo 08:30 - 12:00,14:00 - 18:00; Tu 08:30 - 12:00,14:00 - 18:00; We 08:30 - 12:00,14:00 - 18:00; Th 08:30 - 12:00,14:00 - 18:00; Fr 08:30 - 12:00,14:00 - 18:00; Sa 08:30 - 12:00,14:00 - 18:00",
         "title": "3xHNO",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -1009,7 +1009,7 @@
         "location": "Heinz-Galinski-Str. 15   13347 Berlin",
         "telephone": "0157 81391965",
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 18:00",
         "title": "7 Days Test",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1031,7 +1031,7 @@
         "location": "Anna-Seghers-Str.109 12489  Berlin",
         "telephone": null,
         "details_url": "http://www.adler-apotheke-adlershof.de",
-        "opening_hours": "Th 15:00 - 19:00; Fr 15:00 - 19:00; Sa 09:00 - 15:00; ",
+        "opening_hours": "Th 15:00 - 19:00; Fr 15:00 - 19:00; Sa 09:00 - 15:00",
         "title": "Adler Apotheke Adlershof",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1053,7 +1053,7 @@
         "location": "Behrenstr.72 10117 Berlin",
         "telephone": null,
         "details_url": "https://covid-testservice.de/behrenstrasse",
-        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00; ",
+        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00",
         "title": "Adlon Kempinski Teststation Behrenstraße",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -1075,7 +1075,7 @@
         "location": "Oppelner Str.7 10997 Berlin",
         "telephone": null,
         "details_url": "https://schnelltestzentrum-aerticket.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00",
         "title": "AER Oppelner",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1097,7 +1097,7 @@
         "location": "Boppstr.10 10967 Berlin",
         "telephone": null,
         "details_url": "https://www.aerticket.de/de/unternehmen/corona-schnelltestzentrum-bei-aerticket-in-berlin-kreuzberg",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "AERTICKET",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1119,7 +1119,7 @@
         "location": "Marzahner Promenade 55 12679  Berlin",
         "telephone": null,
         "details_url": "http://www.akademie-notfallmedizin.de",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "AfN - CoronaSchnelltest",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -1141,7 +1141,7 @@
         "location": "Alexanderstr. 1 10178 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00",
         "title": "AIG Schnelltest Zentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1163,7 +1163,7 @@
         "location": "Tempelhofer damm 123  12099  Berlin",
         "telephone": null,
         "details_url": "https://www.schnelltestzentrum.berlin",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00",
         "title": "AIG Schnelltestzentrum Tempelhof",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -1185,7 +1185,7 @@
         "location": "Nonnendamm 33-35 13627 Berlin",
         "telephone": null,
         "details_url": "https://www.aik-berlin.de/",
-        "opening_hours": "Mo 08:00 - 16:00; Tu 08:00 - 16:00; We 08:00 - 16:00; Th 08:00 - 16:00; Fr 08:00 - 16:00; Sa 08:00 - 16:00; Su 08:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 16:00; Tu 08:00 - 16:00; We 08:00 - 16:00; Th 08:00 - 16:00; Fr 08:00 - 16:00; Sa 08:00 - 16:00; Su 08:00 - 16:00",
         "title": "AIK Ambulante Intensiv Krankenpflege GmbH",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -1207,7 +1207,7 @@
         "location": "Grunerstr. 20 10179 Berlin",
         "telephone": null,
         "details_url": "https://www.bezirksapotheke.de/corona-schnelltest-alexa/",
-        "opening_hours": "Mo 08:00 - 12:00,13:00 - 16:00; Tu 08:00 - 12:00,13:00 - 16:00; We 08:00 - 12:00,13:00 - 16:00; Th 08:00 - 12:00,13:00 - 16:00; Fr 08:00 - 12:00,13:00 - 16:00; Sa 08:00 - 12:00,13:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 12:00,13:00 - 16:00; Tu 08:00 - 12:00,13:00 - 16:00; We 08:00 - 12:00,13:00 - 16:00; Th 08:00 - 12:00,13:00 - 16:00; Fr 08:00 - 12:00,13:00 - 16:00; Sa 08:00 - 12:00,13:00 - 16:00",
         "title": "Alexa Testzentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1229,7 +1229,7 @@
         "location": "Pablo-Neruda-Straße 2-4 12559 Berlin",
         "telephone": null,
         "details_url": "https://www.expelcovid19.com/",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; Su 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; Su 10:00 - 19:00",
         "title": "Allende Center Köpenick",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -1251,7 +1251,7 @@
         "location": "Altonaer Str. 85 13581  Berlin",
         "telephone": null,
         "details_url": "http://www.hbtr.eu/",
-        "opening_hours": "Mo 10:00 - 16:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 10:00 - 16:00; Fr 10:00 - 16:00; Sa 10:00 - 16:00; ",
+        "opening_hours": "Mo 10:00 - 16:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 10:00 - 16:00; Fr 10:00 - 16:00; Sa 10:00 - 16:00",
         "title": "Altonaer-Corona-Teststation",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1273,7 +1273,7 @@
         "location": "Breite Str. 20 13597 Berlin",
         "telephone": null,
         "details_url": "https://www.altstadt-apotheke-berlin.de/website/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00",
         "title": "Altstadt-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1295,7 +1295,7 @@
         "location": "Rostocker Str. 15 13059 Berlin",
         "telephone": null,
         "details_url": "https://covisa.de/covisacenter",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00",
         "title": "Amsel Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1317,7 +1317,7 @@
         "location": "Turmstraße 29 10551 Berlin",
         "telephone": null,
         "details_url": "https://www.premium-apotheken-berlin.de/kostenlose-corona-schnelltests/",
-        "opening_hours": "Mo 08:00 - 21:00; Tu 08:00 - 21:00; We 08:00 - 21:00; Th 08:00 - 21:00; Fr 08:00 - 21:00; Sa 08:00 - 21:00; ",
+        "opening_hours": "Mo 08:00 - 21:00; Tu 08:00 - 21:00; We 08:00 - 21:00; Th 08:00 - 21:00; Fr 08:00 - 21:00; Sa 08:00 - 21:00",
         "title": "apotheke 4.0",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1339,7 +1339,7 @@
         "location": "Kurfürstendamm 69 10707 Berlin",
         "telephone": null,
         "details_url": "http://www.apotheke-am-adenauerplatz.de/",
-        "opening_hours": "Mo 10:00 - 16:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 10:00 - 16:00; Fr 10:00 - 16:00; ",
+        "opening_hours": "Mo 10:00 - 16:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 10:00 - 16:00; Fr 10:00 - 16:00",
         "title": "Apotheke am Adenauerplatz Teststelle",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1361,7 +1361,7 @@
         "location": "Fontanestr 4 14193 Berlin",
         "telephone": null,
         "details_url": "https://www.alphega-apotheken.de/apotheke-am-bahnhof-grunewald/berlin-grunewald",
-        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 09:00 - 14:00; ",
+        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 09:00 - 14:00",
         "title": "Apotheke am Bahnhof Grunewald",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1383,7 +1383,7 @@
         "location": "Neue Kantstr. 18 14057 Berlin",
         "telephone": null,
         "details_url": "https://www.apoamfunkturm.de/",
-        "opening_hours": "Th 09:00 - 14:00; ",
+        "opening_hours": "Th 09:00 - 14:00",
         "title": "Apotheke am Funkturm",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1405,7 +1405,7 @@
         "location": "Herrfurthstrasse 9 12049 Berlin",
         "telephone": null,
         "details_url": "https://wirtesten.online/apotheke-am-herrfurthplatz/termin",
-        "opening_hours": "Mo 14:00 - 18:00; Tu 14:00 - 18:00; We 14:00 - 18:00; Th 14:00 - 18:00; Fr 14:00 - 18:00; ",
+        "opening_hours": "Mo 14:00 - 18:00; Tu 14:00 - 18:00; We 14:00 - 18:00; Th 14:00 - 18:00; Fr 14:00 - 18:00",
         "title": "Apotheke am Herrfurthplatz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1427,7 +1427,7 @@
         "location": "Lichtenrader Damm 49 12305 Berlin",
         "telephone": null,
         "details_url": "https://www.apotheke-am-lichtenraderdamm.de/",
-        "opening_hours": "Mo 08:00 - 19:30; Tu 08:00 - 19:30; We 08:00 - 19:30; Th 08:00 - 19:30; Fr 08:00 - 19:30; Sa 08:00 - 19:30; ",
+        "opening_hours": "Mo 08:00 - 19:30; Tu 08:00 - 19:30; We 08:00 - 19:30; Th 08:00 - 19:30; Fr 08:00 - 19:30; Sa 08:00 - 19:30",
         "title": "Apotheke am Lichtenrader Damm",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1449,7 +1449,7 @@
         "location": "Mierendorffplatz 12  10589 Berlin",
         "telephone": null,
         "details_url": "https://www.covisa.de/",
-        "opening_hours": "Mo 08:30 - 18:30; Tu 08:30 - 18:30; We 08:30 - 18:30; Th 08:30 - 18:30; Fr 08:30 - 18:30; Sa 08:30 - 18:30; Su 08:30 - 18:30; ",
+        "opening_hours": "Mo 08:30 - 18:30; Tu 08:30 - 18:30; We 08:30 - 18:30; Th 08:30 - 18:30; Fr 08:30 - 18:30; Sa 08:30 - 18:30; Su 08:30 - 18:30",
         "title": "Apotheke am Mierendorffplatz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1471,7 +1471,7 @@
         "location": "Oranienstr. 158 10969  Berlin",
         "telephone": null,
         "details_url": "https://www.apotheke-am-moritzplatz-berlin.de/",
-        "opening_hours": "Mo 09:00 - 13:00; Tu 09:00 - 13:00; We 09:00 - 13:00; Th 09:00 - 13:00; Fr 09:00 - 13:00; Sa 09:00 - 13:00; ",
+        "opening_hours": "Mo 09:00 - 13:00; Tu 09:00 - 13:00; We 09:00 - 13:00; Th 09:00 - 13:00; Fr 09:00 - 13:00; Sa 09:00 - 13:00",
         "title": "Apotheke am Moritzplatz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1493,7 +1493,7 @@
         "location": "Hermann-Hesse-Str. 4A 13156 Berlin",
         "telephone": null,
         "details_url": "http://www.apo-am-schlosspark.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 14:00",
         "title": "Apotheke am Schlosspark",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1515,7 +1515,7 @@
         "location": "Reichsstr. 22 14052 Berlin",
         "telephone": "030 30099028",
         "details_url": "http://www.covisa.de/",
-        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30; Su 09:30 - 18:30; ",
+        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30; Su 09:30 - 18:30",
         "title": "Apotheke am Steubenplatz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1537,7 +1537,7 @@
         "location": "Strausberger Platz 11-12 10243 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 18:30; Tu 09:00 - 18:30; We 09:00 - 18:30; Th 09:00 - 18:30; Fr 09:00 - 18:30; Sa 09:00 - 13:00; ",
+        "opening_hours": "Mo 09:00 - 18:30; Tu 09:00 - 18:30; We 09:00 - 18:30; Th 09:00 - 18:30; Fr 09:00 - 18:30; Sa 09:00 - 13:00",
         "title": "Apotheke am Strausberger Platz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1559,7 +1559,7 @@
         "location": "Tempelhofer Damm 198-200 12103 Berlin",
         "telephone": null,
         "details_url": "https://www.tdammapotheke.de/website/",
-        "opening_hours": "Mo 08:30 - 15:00; Tu 08:30 - 15:00; We 08:30 - 15:00; Th 08:30 - 15:00; Fr 08:30 - 15:00; Sa 08:30 - 15:00; ",
+        "opening_hours": "Mo 08:30 - 15:00; Tu 08:30 - 15:00; We 08:30 - 15:00; Th 08:30 - 15:00; Fr 08:30 - 15:00; Sa 08:30 - 15:00",
         "title": "Apotheke am T-Damm",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1581,7 +1581,7 @@
         "location": "Carmerstraße 7 10623 Berlin",
         "telephone": null,
         "details_url": "https://www.apotheke-carmer-7.de/",
-        "opening_hours": "Mo 10:00 - 13:30; Tu 10:00 - 13:30; We 10:00 - 13:30; Th 10:00 - 13:30; Fr 10:00 - 13:30; ",
+        "opening_hours": "Mo 10:00 - 13:30; Tu 10:00 - 13:30; We 10:00 - 13:30; Th 10:00 - 13:30; Fr 10:00 - 13:30",
         "title": "Apotheke Carmer-7",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1603,7 +1603,7 @@
         "location": "Bismarckstrasse, 45-47 10627 Berlin",
         "telephone": null,
         "details_url": "https://www.bismarckapotheke.de/corona-test",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00",
         "title": "Apotheke im Bismarck-Karree",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1625,7 +1625,7 @@
         "location": "Passauer Str. 38 10789 Berlin",
         "telephone": null,
         "details_url": "https://www.apothekeimkadewe.de/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00",
         "title": "Apotheke im KaDeWe",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1647,7 +1647,7 @@
         "location": "Frankfurter Allee 111 10247 Berlin",
         "telephone": null,
         "details_url": "https://www.premium-apotheken-berlin.de/kostenlose-corona-schnelltests/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00",
         "title": "Apotheke im Ring-Center I",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1669,7 +1669,7 @@
         "location": "Lausanner Str. 83 12205 Berlin",
         "telephone": null,
         "details_url": "https://www.apotheke-im-schweizer-viertel.de/",
-        "opening_hours": "Mo 08:30 - 20:00; Tu 08:30 - 20:00; We 08:30 - 20:00; Th 08:30 - 20:00; Fr 08:30 - 20:00; Sa 09:00 - 16:00; ",
+        "opening_hours": "Mo 08:30 - 20:00; Tu 08:30 - 20:00; We 08:30 - 20:00; Th 08:30 - 20:00; Fr 08:30 - 20:00; Sa 09:00 - 16:00",
         "title": "Apotheke im Schweizer Viertel",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1691,7 +1691,7 @@
         "location": "Karl-Marx-Str. 27 12043 Berlin",
         "telephone": "030 62903555",
         "details_url": "https://www.apotheke-impuls-berlin.de/website/",
-        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 09:00 - 14:00; ",
+        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 09:00 - 14:00",
         "title": "Apotheke Impuls",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1713,7 +1713,7 @@
         "location": "Schönhauser Allee 79 10439 Berlin",
         "telephone": null,
         "details_url": "https://arcaden-apotheke-berlin.probatix.de/de/pick-slot",
-        "opening_hours": "Mo 08:30 - 20:00; Tu 08:30 - 20:00; We 08:30 - 20:00; Th 08:30 - 20:00; Fr 08:30 - 20:00; Sa 09:00 - 20:00; ",
+        "opening_hours": "Mo 08:30 - 20:00; Tu 08:30 - 20:00; We 08:30 - 20:00; Th 08:30 - 20:00; Fr 08:30 - 20:00; Sa 09:00 - 20:00",
         "title": "Arcaden Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1735,7 +1735,7 @@
         "location": "Elsenstr. 99 12435  Berlin",
         "telephone": null,
         "details_url": "http://www.baerenapotheketreptow.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00",
         "title": "Bären Apotheke Treptow",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1757,7 +1757,7 @@
         "location": "Oranienburger Str 85-86 13437 Berlin",
         "telephone": null,
         "details_url": "http://www.baeren-apotheke-berlin.de/",
-        "opening_hours": "Mo 09:00 - 17:30; Tu 09:00 - 17:30; We 09:00 - 17:30; Th 09:00 - 17:30; Fr 09:00 - 17:30; Sa 09:00 - 13:30; ",
+        "opening_hours": "Mo 09:00 - 17:30; Tu 09:00 - 17:30; We 09:00 - 17:30; Th 09:00 - 17:30; Fr 09:00 - 17:30; Sa 09:00 - 13:30",
         "title": "Bären-Apotheke Wittenau",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1779,7 +1779,7 @@
         "location": "Havemannstr. 24 12689 Berlin",
         "telephone": null,
         "details_url": "https://www.baerliner-apotheke-app.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00",
         "title": "Bärliner Apotheke Marzahn e.K.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1801,7 +1801,7 @@
         "location": "Schmiljan str.18    12161  Berlin",
         "telephone": null,
         "details_url": "http://www.beautybarberlin.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 10:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 10:00 - 16:00",
         "title": "Beauty Bar Friedenau",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1823,7 +1823,7 @@
         "location": "Joachimsthaler Str. 10 10719  Berlin",
         "telephone": null,
         "details_url": "https://www.belladerma.de/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00",
         "title": "BellaDerma - Teststation Corona",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1845,7 +1845,7 @@
         "location": "Skalitzer Straße 133 10999 Berlin",
         "telephone": null,
         "details_url": "https://app.no-q.info/berg-apotheke/checkins#/1276/2021-04-13",
-        "opening_hours": "Mo 14:00 - 16:00; Tu 14:00 - 16:00; We 14:00 - 16:00; Th 14:00 - 16:00; Fr 14:00 - 16:00; Sa 14:00 - 16:00; ",
+        "opening_hours": "Mo 14:00 - 16:00; Tu 14:00 - 16:00; We 14:00 - 16:00; Th 14:00 - 16:00; Fr 14:00 - 16:00; Sa 14:00 - 16:00",
         "title": "Berg-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1867,7 +1867,7 @@
         "location": "Württembergallee 1 14052 Berlin",
         "telephone": null,
         "details_url": "https://berlin-corona-test.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 16:00; Su 09:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 16:00; Su 09:00 - 16:00",
         "title": "Berlin Corona Testzentrum",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -1889,7 +1889,7 @@
         "location": "Schloßstrasse 34-36 12163 Berlin",
         "telephone": null,
         "details_url": "http://www.berlinda-apotheke.com/",
-        "opening_hours": "Mo 10:00 - 18:30; Tu 10:00 - 18:30; We 10:00 - 18:30; Th 10:00 - 18:30; Fr 10:00 - 18:30; Sa 10:00 - 18:30; ",
+        "opening_hours": "Mo 10:00 - 18:30; Tu 10:00 - 18:30; We 10:00 - 18:30; Th 10:00 - 18:30; Fr 10:00 - 18:30; Sa 10:00 - 18:30",
         "title": "Berlinda Apotheke \"das Schloß\", Testzentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1911,7 +1911,7 @@
         "location": "Rathausstr. 5 10178 Berlin",
         "telephone": null,
         "details_url": "https://www.bezirksapotheke.de/corona-schnelltest-alexanderplatz/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00",
         "title": "Bezirksapotheke am Roten Rathaus",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1933,7 +1933,7 @@
         "location": "Warschauer Str. 27 10243 Berlin",
         "telephone": null,
         "details_url": "https://www.bezirksapotheke.de/corona-schnelltest-friedrichshain/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 09:00 - 18:00",
         "title": "Bezirksapotheke Friedrichshain",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1955,7 +1955,7 @@
         "location": "Karl-Marx-Str. 131 12043 Berlin",
         "telephone": "0176 41299406",
         "details_url": "",
-        "opening_hours": "Mo 12:00 - 20:00; Tu 12:00 - 20:00; We 12:00 - 20:00; Th 12:00 - 20:00; Fr 12:00 - 20:00; ",
+        "opening_hours": "Mo 12:00 - 20:00; Tu 12:00 - 20:00; We 12:00 - 20:00; Th 12:00 - 20:00; Fr 12:00 - 20:00",
         "title": "BG Mobil-Testen",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1977,7 +1977,7 @@
         "location": "Kurfürstendamm 203-205 10719 Berlin",
         "telephone": null,
         "details_url": "https://www.apotheke-bio-app.de/",
-        "opening_hours": "Mo 08:30 - 20:00; Tu 08:30 - 20:00; We 08:30 - 20:00; Th 08:30 - 20:00; Fr 08:30 - 20:00; Sa 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:30 - 20:00; Tu 08:30 - 20:00; We 08:30 - 20:00; Th 08:30 - 20:00; Fr 08:30 - 20:00; Sa 08:00 - 20:00",
         "title": "Bio 7.0 Apotheke e.K.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -1999,7 +1999,7 @@
         "location": "Bahnhofstr. 17A 13125 Berlin",
         "telephone": null,
         "details_url": "https://www.terminland.eu/birkenapotheke/",
-        "opening_hours": "We 11:00 - 13:00; Fr 09:00 - 11:00; ",
+        "opening_hours": "We 11:00 - 13:00; Fr 09:00 - 11:00",
         "title": "Birken Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2021,7 +2021,7 @@
         "location": "Stralauer Allee 17c   10245 Berlin",
         "telephone": "030 45957175",
         "details_url": "https://blackswangroup.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00",
         "title": "Black Swan",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2043,7 +2043,7 @@
         "location": "Kottbusser Str. 1 10999 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00",
         "title": "Blackbull Schnelltest Zentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2065,7 +2065,7 @@
         "location": "Wilmersdorfer Straße 46 10627 Berlin",
         "telephone": null,
         "details_url": "http://www.bong-apotheke.de",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00",
         "title": "Bong-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2087,7 +2087,7 @@
         "location": "Unter den Linden 69d 10117  Berlin",
         "telephone": null,
         "details_url": "https://app.no-q.info/brandenburger-tor-apotheke/checkins",
-        "opening_hours": "Mo 10:00 - 17:00; Tu 10:00 - 17:00; We 10:00 - 17:00; Th 10:00 - 17:00; Fr 10:00 - 17:00; ",
+        "opening_hours": "Mo 10:00 - 17:00; Tu 10:00 - 17:00; We 10:00 - 17:00; Th 10:00 - 17:00; Fr 10:00 - 17:00",
         "title": "Brandenburger Tor Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2109,7 +2109,7 @@
         "location": "Kurfürstendamm 71 10709  Berlin",
         "telephone": "030 32766730",
         "details_url": "https://brillant-apotheke.de/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00",
         "title": "Brillant Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2131,7 +2131,7 @@
         "location": "Kaiser-Friedrich-Straße 62a 10627 Berlin",
         "telephone": null,
         "details_url": "http://www.brooks-test-zentrum.de",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00",
         "title": "Brooks Testzentrum",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2153,7 +2153,7 @@
         "location": "Bundesallee 92 12161 Berlin",
         "telephone": null,
         "details_url": "https://www.burger-apotheke.de/",
-        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 08:30 - 14:00; ",
+        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 08:30 - 14:00",
         "title": "Burger Apotheke Corona Testzentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2175,7 +2175,7 @@
         "location": "Eisenacher Str. 74 10823  Berlin",
         "telephone": null,
         "details_url": "https://www.buergertest-berlin.de/",
-        "opening_hours": "Mo 08:00 - 19:30; Tu 08:00 - 19:30; We 08:00 - 19:30; Th 08:00 - 19:30; Fr 08:00 - 19:30; Sa 08:00 - 19:30; Su 08:00 - 19:30; ",
+        "opening_hours": "Mo 08:00 - 19:30; Tu 08:00 - 19:30; We 08:00 - 19:30; Th 08:00 - 19:30; Fr 08:00 - 19:30; Sa 08:00 - 19:30; Su 08:00 - 19:30",
         "title": "Bürgertest Berlin Schönberg",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2197,7 +2197,7 @@
         "location": "Merseburger Str. 8 10823 Berlin",
         "telephone": null,
         "details_url": "http://www.cafe-wohnzimmer.berlin/",
-        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; Su 10:00 - 20:00; ",
+        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; Su 10:00 - 20:00",
         "title": "Café Wohnzimmer",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2219,7 +2219,7 @@
         "location": "Dudenstr. 11 10965 Berlin",
         "telephone": null,
         "details_url": "http://www.cartal-medical.de/",
-        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00; ",
+        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00",
         "title": "Cartal Medical",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2241,7 +2241,7 @@
         "location": "Neuenburger Straße 19 10969 Berlin",
         "telephone": null,
         "details_url": "https://www.checkpoint-schnelltest.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Checkpoint Schnelltest",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2263,7 +2263,7 @@
         "location": "Heidelberger Str. 90 12435 Berlin",
         "telephone": null,
         "details_url": "https://www.cobusters.de/heidelbergerstr90",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00",
         "title": "COBUSTERS @EDEKA Lawrenz Alt-Treptow",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2285,7 +2285,7 @@
         "location": "Rothenbachstr. 1 13089  Berlin",
         "telephone": null,
         "details_url": "https://clickandtest.de/COBUSTERSPankow",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00",
         "title": "COBUSTERS @ShellTankstelle Pankow",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2307,7 +2307,7 @@
         "location": "Gleimstraße 41 10437 Berlin",
         "telephone": null,
         "details_url": "https://www.cobusters.de/gleimstr41",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00",
         "title": "COBUSTERS Corona-Schnelltest-Team",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2329,7 +2329,7 @@
         "location": "Schlesische Str. 29 10997  Berlin",
         "telephone": null,
         "details_url": "https://www.cobusters.de/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00",
         "title": "COBUSTERS Schwiliko Schlesische Str. 29",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2351,7 +2351,7 @@
         "location": "Lietzenburger Str. 22 10789 Berlin",
         "telephone": null,
         "details_url": "https://corona-express-test.cms.webnode.com/",
-        "opening_hours": "Mo 07:00 - 14:00,15:00 - 21:00; Tu 07:00 - 14:00,15:00 - 21:00; We 07:00 - 14:00,15:00 - 21:00; Th 07:00 - 14:00,15:00 - 21:00; Fr 07:00 - 14:00,15:00 - 21:00; Sa 07:00 - 14:00,15:00 - 21:00; Su 07:00 - 14:00,15:00 - 21:00; ",
+        "opening_hours": "Mo 07:00 - 14:00,15:00 - 21:00; Tu 07:00 - 14:00,15:00 - 21:00; We 07:00 - 14:00,15:00 - 21:00; Th 07:00 - 14:00,15:00 - 21:00; Fr 07:00 - 14:00,15:00 - 21:00; Sa 07:00 - 14:00,15:00 - 21:00; Su 07:00 - 14:00,15:00 - 21:00",
         "title": "Corona Express Test am Ku'damm",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2373,7 +2373,7 @@
         "location": "Moselstr. 1 12159 Berlin",
         "telephone": null,
         "details_url": "https://corona-express-test.de/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 14:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 14:00",
         "title": "Corona Express Test Berlin Moselstr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2395,7 +2395,7 @@
         "location": "Ringstr. 78 12105 Berlin",
         "telephone": null,
         "details_url": "https://corona-express-test.de/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 14:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 14:00",
         "title": "Corona Express Test Berlin Ringstr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2417,7 +2417,7 @@
         "location": "Wittenbergplatz 5 10789  Berlin",
         "telephone": "0162 4042617",
         "details_url": "https://professionaleventsallinone.com/",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00",
         "title": "Corona Quicktest am Wittenbergplatz",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2439,7 +2439,7 @@
         "location": "Fasanenstraße 16 10623 Berlin",
         "telephone": null,
         "details_url": "https://www.coronaschnelltest-kudamm.de",
-        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00; ",
+        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00",
         "title": "Corona Schnelltest am Kudamm",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2461,7 +2461,7 @@
         "location": "Charlottenstr. 3 13597 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00",
         "title": "Corona Schnelltest Charlottenstr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2483,7 +2483,7 @@
         "location": "Mariendorfer Damm 418 12107 Berlin",
         "telephone": "030 74104217",
         "details_url": "https://corona-schnelltest-mariendorf.business.site/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 11:00 - 16:00; Su 11:00 - 16:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 11:00 - 16:00; Su 11:00 - 16:00",
         "title": "Corona Schnelltest Mariendorf",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2505,7 +2505,7 @@
         "location": "Breite Str. 25 13597 Berlin",
         "telephone": null,
         "details_url": "https://cstfb.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00",
         "title": "Corona Schnelltest Station Spandau",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2527,7 +2527,7 @@
         "location": "Kurfürstendamm 115b 10711 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 18:00",
         "title": "Corona Schnelltest Station To Go",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2549,7 +2549,7 @@
         "location": "Alboinstraße 96-110 12103 Berlin",
         "telephone": null,
         "details_url": "http://www.corona-schnelltest.center/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00",
         "title": "Corona Schnellteststation Tempelhof",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2571,7 +2571,7 @@
         "location": "Kaiser-Wilhelm-Platz 1 10827 Berlin",
         "telephone": null,
         "details_url": "https://app.no-q.info/corona-schnelltest-schoeneberg-kwa/checkins#",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 14:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 14:00",
         "title": "Corona Schnelltestzentrum Kaiser-Wilhelm-Apotheke",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2593,7 +2593,7 @@
         "location": "Helene Weigel Platz 11 12681 Berlin",
         "telephone": null,
         "details_url": "http://www.apo-am-springpfuhl.de/",
-        "opening_hours": "Mo 08:30 - 12:00; Tu 14:00 - 18:00; We 08:30 - 12:00; Th 14:00 - 18:00; Fr 08:30 - 12:00; ",
+        "opening_hours": "Mo 08:30 - 12:00; Tu 14:00 - 18:00; We 08:30 - 12:00; Th 14:00 - 18:00; Fr 08:30 - 12:00",
         "title": "Corona Schnelltestzentrum Marzahn",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2615,7 +2615,7 @@
         "location": "Westhafenstr. 1, Sektor B, Halle 1 13353 Berlin",
         "telephone": null,
         "details_url": "https://corona-test-berlin.de/termin/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 09:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 09:00 - 14:00",
         "title": "Corona Test Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2637,7 +2637,7 @@
         "location": "Stromstr. 21 10551 Berlin",
         "telephone": null,
         "details_url": "http://corona-test-mitte.de/",
-        "opening_hours": "Mo 07:00 - 12:00,15:00 - 20:00; Tu 07:00 - 12:00,15:00 - 20:00; We 07:00 - 12:00,15:00 - 20:00; Th 07:00 - 12:00,15:00 - 20:00; Fr 07:00 - 12:00,15:00 - 20:00; Sa 07:00 - 12:00,15:00 - 20:00; Su 07:00 - 12:00,15:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 12:00,15:00 - 20:00; Tu 07:00 - 12:00,15:00 - 20:00; We 07:00 - 12:00,15:00 - 20:00; Th 07:00 - 12:00,15:00 - 20:00; Fr 07:00 - 12:00,15:00 - 20:00; Sa 07:00 - 12:00,15:00 - 20:00; Su 07:00 - 12:00,15:00 - 20:00",
         "title": "Corona Test Berlin Mitte",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2659,7 +2659,7 @@
         "location": "Grenzallee, Naumburger Str. 33 12057  Berlin",
         "telephone": null,
         "details_url": "http://corona-test-neukoelln.de.dedi4900.your-server.de/#bookingwidget",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 18:00",
         "title": "Corona Test Neukölln",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2681,7 +2681,7 @@
         "location": "Schönhauser Allee 46A 10437 Berlin",
         "telephone": null,
         "details_url": "https://www.corona-test-prenzlauerberg.de/",
-        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00; Su 07:00 - 19:00; ",
+        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00; Su 07:00 - 19:00",
         "title": "Corona Test Prenzlauer Berg",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2703,7 +2703,7 @@
         "location": "Luckenwalder Straße 4-6 10963 Berlin",
         "telephone": null,
         "details_url": "https://test-station.berlin/termine",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Corona Test Station Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2725,7 +2725,7 @@
         "location": "Augsburger Str. 41 10789  Berlin",
         "telephone": null,
         "details_url": "https://test-station.berlin/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Corona Test Station Berlin Dorinth Hotel",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2747,7 +2747,7 @@
         "location": "Grunewaldstr. 17 10823 Berlin",
         "telephone": null,
         "details_url": "http://wasserundhahn.de/17/",
-        "opening_hours": "Mo 07:00 - 21:00; Tu 07:00 - 21:00; We 07:00 - 21:00; Th 07:00 - 21:00; Fr 07:00 - 21:00; Sa 07:00 - 21:00; ",
+        "opening_hours": "Mo 07:00 - 21:00; Tu 07:00 - 21:00; We 07:00 - 21:00; Th 07:00 - 21:00; Fr 07:00 - 21:00; Sa 07:00 - 21:00",
         "title": "Corona Test Zentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2769,7 +2769,7 @@
         "location": "Lindower Str. 24 13347  Berlin",
         "telephone": null,
         "details_url": "http://www.corona-test-zentrum-berlin.de/",
-        "opening_hours": "Mo 08:00 - 22:00; Tu 08:00 - 22:00; We 08:00 - 22:00; Th 08:00 - 22:00; Fr 08:00 - 22:00; Sa 08:00 - 22:00; Su 08:00 - 22:00; ",
+        "opening_hours": "Mo 08:00 - 22:00; Tu 08:00 - 22:00; We 08:00 - 22:00; Th 08:00 - 22:00; Fr 08:00 - 22:00; Sa 08:00 - 22:00; Su 08:00 - 22:00",
         "title": "Corona Test Zentrum Berlin Lindower Str.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2791,7 +2791,7 @@
         "location": "Kottbusser Str. 11 10999 Berlin",
         "telephone": null,
         "details_url": "https://schnelltestberlin.de/buergertest-kreuzberg/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "Corona Test Zentrum Kreuzberg Kottbusser Str.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2813,7 +2813,7 @@
         "location": "Richardstr. 85/86 12043 Berlin",
         "telephone": null,
         "details_url": "http://schnelltestberlin.de/buergertest-neukoelln",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Corona Test Zentrum Neukölln",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2835,7 +2835,7 @@
         "location": "Alt-Rudow 12 12357 Berlin",
         "telephone": null,
         "details_url": "https://testtermin.de/corona-testzentrum-rudow-12357-berlin/",
-        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30; ",
+        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30",
         "title": "Corona Test-Zentrum Alt-Rudow",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2857,7 +2857,7 @@
         "location": "Assmannshauserstraße 11a 14197 Berlin",
         "telephone": null,
         "details_url": "https://book.timify.com/?accountId=6055cc896722ef117b2f1676&hideCloseButton=true&enterpriseId=5fd38f8439910c11ca28d37d",
-        "opening_hours": "Mo 09:30 - 11:30; Tu 09:30 - 11:30; We 09:30 - 11:30,17:00 - 19:30; Th 09:30 - 11:30; Fr 09:30 - 11:30,17:00 - 19:30; Sa 08:30 - 10:30; ",
+        "opening_hours": "Mo 09:30 - 11:30; Tu 09:30 - 11:30; We 09:30 - 11:30,17:00 - 19:30; Th 09:30 - 11:30; Fr 09:30 - 11:30,17:00 - 19:30; Sa 08:30 - 10:30",
         "title": "Corona Testcenter am Rüdesheimer Platz",
         "hints": [
           "PCR-Nachtestung: mit",
@@ -2879,7 +2879,7 @@
         "location": "Wilmersdorfer Straße 46 10627 Berlin",
         "telephone": null,
         "details_url": "https://coronatestcenterberlin.de/termin-buchen/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00",
         "title": "Corona Testcenter Berlin Wilmersdorfer Str.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -2901,7 +2901,7 @@
         "location": "Pablo-Neruda-Straße 2-4 12559 Berlin",
         "telephone": null,
         "details_url": "http://covid-kudamm.de/index.php/terminbuchung",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "Corona Teststation Allende-Center",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2923,7 +2923,7 @@
         "location": "Regattastr. 141 12527  Berlin",
         "telephone": null,
         "details_url": "https://test-station.berlin/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Corona Teststation Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2945,7 +2945,7 @@
         "location": "Kranoldplatz 5,  12209  Berlin",
         "telephone": null,
         "details_url": "https://testedichschnell.de/jp-berlin-lichterfelde",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 15:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 15:00",
         "title": "Corona Teststation Berlin-Lichterfelde (Ost)",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2967,7 +2967,7 @@
         "location": "Königstraße 57B 14109 Berlin",
         "telephone": null,
         "details_url": "https://testedichschnell.de/jp-berlin-wannsee/",
-        "opening_hours": "Mo 07:00 - 18:00; Tu 08:00 - 18:30; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 07:00 - 18:00; Sa 09:00 - 14:00; ",
+        "opening_hours": "Mo 07:00 - 18:00; Tu 08:00 - 18:30; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 07:00 - 18:00; Sa 09:00 - 14:00",
         "title": "Corona Teststation Berlin-Wannsee",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -2989,7 +2989,7 @@
         "location": "Alt-Biesdorf 38 12683  Berlin ",
         "telephone": null,
         "details_url": "https://www.resinbyangiee.de/",
-        "opening_hours": "Mo 07:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00; ",
+        "opening_hours": "Mo 07:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00",
         "title": "Corona Teststation Immelmann Alt-Biesdorf",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3011,7 +3011,7 @@
         "location": "An der Ostbahn 3 10243  Berlin",
         "telephone": "0178 4550336 ",
         "details_url": "https://www.resinbyangiee.de/",
-        "opening_hours": "Mo 07:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00; ",
+        "opening_hours": "Mo 07:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00",
         "title": "Corona Teststation Immelmann An der Ostbahn",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3033,7 +3033,7 @@
         "location": "Attilastr. 52 12105 Berlin",
         "telephone": "0178 4550336",
         "details_url": "https://www.resinbyangiee.de/",
-        "opening_hours": "Mo 09:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00; ",
+        "opening_hours": "Mo 09:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00",
         "title": "Corona Teststation Immelmann Attilastr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3055,7 +3055,7 @@
         "location": "Ellen-Epstein-Str. 1  10559 Berlin",
         "telephone": "0178 4550336",
         "details_url": "https://www.resinbyangiee.de/",
-        "opening_hours": "Mo 07:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00; ",
+        "opening_hours": "Mo 07:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00",
         "title": "Corona Teststation Immelmann Ellen-Epstein-Str.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3077,7 +3077,7 @@
         "location": "Ferdinand-Schultze-Str. 106 13055  Berlin",
         "telephone": "0178 4550336",
         "details_url": "https://www.resinbyangiee.de/",
-        "opening_hours": "Mo 07:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00; ",
+        "opening_hours": "Mo 07:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00",
         "title": "Corona Teststation Immelmann Ferdinand-Schultze-Str.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3099,7 +3099,7 @@
         "location": "Roelckestr. 108 - 109 13086  Berlin",
         "telephone": "0178 4550336",
         "details_url": "https://www.resinbyangiee.de/",
-        "opening_hours": "Mo 07:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00; ",
+        "opening_hours": "Mo 07:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00",
         "title": "Corona Teststation Immelmann Roelckestr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3121,7 +3121,7 @@
         "location": "Salvador-Allende-Str. 115 12559  Berlin",
         "telephone": null,
         "details_url": "https://www.resinbyangiee.de/",
-        "opening_hours": "Mo 07:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00; ",
+        "opening_hours": "Mo 07:30 - 20:00; Tu 07:30 - 20:00; We 07:30 - 20:00; Th 07:30 - 20:00; Fr 07:30 - 20:00; Sa 07:30 - 20:00",
         "title": "Corona Teststation Immelmann Salvador-Allende-Str.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3143,7 +3143,7 @@
         "location": "Yorckstr.38/39  10965 Berlin",
         "telephone": "0178 4550336 ",
         "details_url": "https://www.resinbyangiee.de/",
-        "opening_hours": "Mo 08:00 - 21:00; Tu 08:00 - 21:00; We 08:00 - 21:00; Th 08:00 - 21:00; Fr 08:00 - 21:00; Sa 08:00 - 21:00; ",
+        "opening_hours": "Mo 08:00 - 21:00; Tu 08:00 - 21:00; We 08:00 - 21:00; Th 08:00 - 21:00; Fr 08:00 - 21:00; Sa 08:00 - 21:00",
         "title": "Corona Teststation Immelmann Yorckstr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3165,7 +3165,7 @@
         "location": "Marienfelder Chaussee 143 12349  Berlin",
         "telephone": null,
         "details_url": "https://testen.berlin/purus-curae",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00",
         "title": "Corona Teststation Marienfelder Chaussee",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3187,7 +3187,7 @@
         "location": "Fuldastr. 58 12043 Berlin",
         "telephone": null,
         "details_url": "https://coronatestneukoelln.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 09:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 09:00 - 19:00",
         "title": "Corona Teststation Neukölln Fuldastr.",
         "hints": [
           "PCR-Nachtestung: moeglich_dritt",
@@ -3209,7 +3209,7 @@
         "location": "Markstraße 1 13409 Berlin",
         "telephone": null,
         "details_url": "https://www.corona-teststation-reinickendorf.de/",
-        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00; Su 07:00 - 19:00; ",
+        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00; Su 07:00 - 19:00",
         "title": "Corona Teststation U-Bahnhof Franz Neumann Platz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3231,7 +3231,7 @@
         "location": "Markstraße 1  13409  Berlin",
         "telephone": null,
         "details_url": "https://www.corona-teststation-reinickendorf.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00",
         "title": "Corona Teststation U-Bahnhof Residenzstraße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3253,7 +3253,7 @@
         "location": "Königsberger Str. 1   12207 Berlin",
         "telephone": null,
         "details_url": "www.Corona-Teststelle-berlin.de",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Corona Teststelle Lichterfelde Ost",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3275,7 +3275,7 @@
         "location": "Platz vor dem neuen Tor 2 10115 Berlin",
         "telephone": null,
         "details_url": "https://berlin.testcenter-corona.de/",
-        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; Su 10:00 - 20:00; ",
+        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; Su 10:00 - 20:00",
         "title": "Corona Testzentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3297,7 +3297,7 @@
         "location": "Uhlandstraße 181-183 10623 Berlin",
         "telephone": null,
         "details_url": "http://schnelltestberlin.de/buergertest-Charlottenburg",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "Corona Testzentrum am Ku'damm ",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3319,7 +3319,7 @@
         "location": "Oranienburger Chaussee 64A 13465 Berlin",
         "telephone": null,
         "details_url": "https://www.nina-dox.de/",
-        "opening_hours": "Mo 09:00 - 15:00; Tu 09:00 - 15:00; We 09:00 - 15:00; Th 09:00 - 15:00; Fr 09:00 - 15:00; ",
+        "opening_hours": "Mo 09:00 - 15:00; Tu 09:00 - 15:00; We 09:00 - 15:00; Th 09:00 - 15:00; Fr 09:00 - 15:00",
         "title": "Corona Testzentrum B96",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3341,7 +3341,7 @@
         "location": "Boxhagenerstr. 67 10245 Berlin",
         "telephone": null,
         "details_url": "https://app.calendarapp.de/test_calendar/?id=07aa55efa914bd335cfcfae098ed58fc&lang=de",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00",
         "title": "Corona Testzentrum Boxhagenerstr.67",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3363,7 +3363,7 @@
         "location": "Auguststraße 20 10117 Berlin",
         "telephone": null,
         "details_url": "http://www.schnelltestberlin.de/buergertest-Mitte ",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "Corona Testzentrum Mitte",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3385,7 +3385,7 @@
         "location": "Erkstr. 6 12043 Berlin",
         "telephone": null,
         "details_url": "https://testen.berlin/corona-testzentrum",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 10:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 10:00 - 16:00",
         "title": "Corona Testzentrum NEUKÖLLN Erkstr. 6",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3407,7 +3407,7 @@
         "location": "Grabbeallee 59 13156  Berlin",
         "telephone": null,
         "details_url": "https://corona-testzentrum-pankow.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 10:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 10:00 - 16:00",
         "title": "Corona Testzentrum Pankow",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3429,7 +3429,7 @@
         "location": "Stargarder Strasse 44 10437 Berlin",
         "telephone": null,
         "details_url": "https://www.corona-test-prenzlauerallee.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00",
         "title": "Corona Testzentrum Prenzlauer Allee",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3451,7 +3451,7 @@
         "location": "Prenzlauer Allee 224 10405 Berlin",
         "telephone": null,
         "details_url": "https://corona-testzentrum-berlin.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00",
         "title": "Corona Testzentrum Prenzlauer Berg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3473,7 +3473,7 @@
         "location": "Lahnstr. 84 12055 Berlin",
         "telephone": null,
         "details_url": "https://testen.berlin/purus-curae",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Corona Testzentrum purus curae",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3495,7 +3495,7 @@
         "location": "Eichborndamm 294-296 13437 Berlin",
         "telephone": null,
         "details_url": "http://schnelltest-reinickendorf.berlin/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00",
         "title": "Corona Testzentrum Reinickendorf",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3517,7 +3517,7 @@
         "location": "Weinbergsweg, 1A 10119  Berlin",
         "telephone": null,
         "details_url": "https://www.corona-teststelle-berlin.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Corona Testzentrum Rosenthaler Platz",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3539,7 +3539,7 @@
         "location": "Sachsendamm 47 (IKEA Parkplatz) 10829 Berlin",
         "telephone": null,
         "details_url": "http://corona-testzentrum-tempelhof.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 09:00 - 18:00",
         "title": "Corona Testzentrum Tempelhof",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3561,7 +3561,7 @@
         "location": "Teltower Damm 26-28 14169 Berlin",
         "telephone": null,
         "details_url": "https://www.expresstestzentrum.de/",
-        "opening_hours": "Mo 09:30 - 16:00; Tu 09:30 - 16:00; We 09:30 - 16:00; Th 09:30 - 16:00; Fr 09:30 - 16:00; Sa 10:00 - 14:00; ",
+        "opening_hours": "Mo 09:30 - 16:00; Tu 09:30 - 16:00; We 09:30 - 16:00; Th 09:30 - 16:00; Fr 09:30 - 16:00; Sa 10:00 - 14:00",
         "title": "Corona Testzentrum Zehlendorf",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3583,7 +3583,7 @@
         "location": "Kottbusser Damm 97   10967  Berlin",
         "telephone": "0151 66804195",
         "details_url": "",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00",
         "title": "Corona Zentrum HT",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3605,7 +3605,7 @@
         "location": "Meinekestr. 25 10719  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00",
         "title": "Corona-City",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3627,7 +3627,7 @@
         "location": "Manfred-von-Richthofen-Str. 15 12101  Berlin",
         "telephone": null,
         "details_url": "https://www.corona-express-test.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 18:00",
         "title": "Corona-Express-Test Manfred-von Richthofen-Str.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3649,7 +3649,7 @@
         "location": "Rheinstr. 36 12161  Berlin",
         "telephone": null,
         "details_url": "https://www.corona-express-test.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 18:00",
         "title": "Corona-Express-Test Rheinstr.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3671,7 +3671,7 @@
         "location": "Mertensstr. 36 13587  Berlin",
         "telephone": "0176 43439643",
         "details_url": "http://www.kaya-hygiene.com/defaultsite",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00",
         "title": "Corona-Schnelltest KAYA",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3693,7 +3693,7 @@
         "location": "Brunsbütteler Damm 274   13591  Berlin",
         "telephone": null,
         "details_url": "https://testedichschnell.de/berlin-brunsbuetteler-damm",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00",
         "title": "Corona-schnellteststation REWE Brunsbütteler Damm",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3737,7 +3737,7 @@
         "location": "Weißenseer Weg 111  10369  Berlin",
         "telephone": "030 5509344",
         "details_url": "https://zaumberlin.de",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 16:00; Su 09:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 16:00; Su 09:00 - 16:00",
         "title": "Corona-Schnelltestzentrum ZAUM",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3759,7 +3759,7 @@
         "location": "Kladower Damm 221 14089 Berlin",
         "telephone": null,
         "details_url": "https://www.doctolib.de/testzentrum-covid/berlin/teststelle-havelhoehe",
-        "opening_hours": "Mo 13:30 - 18:00; Tu 13:30 - 18:00; We 13:30 - 18:00; Th 13:30 - 18:00; Fr 13:30 - 18:00; Sa 13:30 - 18:00; ",
+        "opening_hours": "Mo 13:30 - 18:00; Tu 13:30 - 18:00; We 13:30 - 18:00; Th 13:30 - 18:00; Fr 13:30 - 18:00; Sa 13:30 - 18:00",
         "title": "CORONA-SCREENING-AMBULANZ-HAVELHÖHE Haus 16",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3781,7 +3781,7 @@
         "location": "Windscheidstrasse 19 10627 Berlin",
         "telephone": null,
         "details_url": "https://www.doctolib.de/testzentrum-covid/berlin/covid-iflb-laboratoriumsmedizin-berlin-gmbh",
-        "opening_hours": "Mo 08:00 - 15:00; Tu 08:00 - 15:00; We 08:00 - 15:00; Th 15:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 15:00; Tu 08:00 - 15:00; We 08:00 - 15:00; Th 15:00 - 19:00",
         "title": "Corona-Screening-Windscheidstraße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3803,7 +3803,7 @@
         "location": "Bernauer Straße 69-73 13507 Berlin",
         "telephone": null,
         "details_url": "https://testedichschnell.de/jp-berlin-tegel",
-        "opening_hours": "Mo 07:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 07:00 - 19:00; Sa 09:00 - 16:00; ",
+        "opening_hours": "Mo 07:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 07:00 - 19:00; Sa 09:00 - 16:00",
         "title": "Corona-Teststation Tegel-Süd",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3825,7 +3825,7 @@
         "location": "Kirchstr. 4 12555 Berlin",
         "telephone": null,
         "details_url": "https://www.wundervino.de/",
-        "opening_hours": "Mo 07:30 - 18:30; Tu 07:30 - 18:30; We 07:30 - 18:30; Th 07:30 - 18:30; Fr 07:30 - 18:30; Sa 07:30 - 18:30; ",
+        "opening_hours": "Mo 07:30 - 18:30; Tu 07:30 - 18:30; We 07:30 - 18:30; Th 07:30 - 18:30; Fr 07:30 - 18:30; Sa 07:30 - 18:30",
         "title": "Corona-Teststation wundervino an der Kirche",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -3847,7 +3847,7 @@
         "location": "Ollenhauerstr. 104 13403 Berlin",
         "telephone": null,
         "details_url": "https://ctb-corona-testzentrum-berlin.de",
-        "opening_hours": "Mo 07:00 - 21:00; Tu 07:00 - 21:00; We 07:00 - 21:00; Th 07:00 - 21:00; Fr 07:00 - 21:00; Sa 07:00 - 21:00; ",
+        "opening_hours": "Mo 07:00 - 21:00; Tu 07:00 - 21:00; We 07:00 - 21:00; Th 07:00 - 21:00; Fr 07:00 - 21:00; Sa 07:00 - 21:00",
         "title": "Corona-Testzentrum Berlin Ollenhauerstr.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3869,7 +3869,7 @@
         "location": "Pestalozzistr. 13 12557 Berlin",
         "telephone": null,
         "details_url": "https://www.jokerbowl.de/",
-        "opening_hours": "Mo 08:00 - 13:00,14:30 - 18:00; Tu 08:00 - 13:00,14:30 - 18:00; We 08:00 - 13:00,14:30 - 20:00; Th 08:00 - 13:00,14:30 - 18:00; Fr 08:00 - 13:00,14:30 - 18:00; Sa 08:00 - 15:00; Su 10:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 13:00,14:30 - 18:00; Tu 08:00 - 13:00,14:30 - 18:00; We 08:00 - 13:00,14:30 - 20:00; Th 08:00 - 13:00,14:30 - 18:00; Fr 08:00 - 13:00,14:30 - 18:00; Sa 08:00 - 15:00; Su 10:00 - 14:00",
         "title": "Corona-Testzentrum Köpenick im Jokerbowl",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3891,7 +3891,7 @@
         "location": "Stromstr. 10b 10559  Berlin",
         "telephone": "03020006991",
         "details_url": "https://coronatestzentrumberlin.de/",
-        "opening_hours": "Mo 07:30 - 21:00; Tu 07:30 - 21:00; We 07:30 - 21:00; Th 07:30 - 21:00; Fr 07:30 - 21:00; Sa 07:30 - 21:00; Su 07:30 - 21:00; ",
+        "opening_hours": "Mo 07:30 - 21:00; Tu 07:30 - 21:00; We 07:30 - 21:00; Th 07:30 - 21:00; Fr 07:30 - 21:00; Sa 07:30 - 21:00; Su 07:30 - 21:00",
         "title": "Corona-Testzentrum-Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3913,7 +3913,7 @@
         "location": "Warschauer Pl. 18 10245 Berlin",
         "telephone": null,
         "details_url": "http://www.corona-attest.de/defaultsite",
-        "opening_hours": "Mo 09:00 - 21:00; Tu 09:00 - 21:00; We 09:00 - 21:00; Th 09:00 - 21:00; Fr 09:00 - 21:00; Sa 09:00 - 21:00; Su 09:00 - 21:00; ",
+        "opening_hours": "Mo 09:00 - 21:00; Tu 09:00 - 21:00; We 09:00 - 21:00; Th 09:00 - 21:00; Fr 09:00 - 21:00; Sa 09:00 - 21:00; Su 09:00 - 21:00",
         "title": "CoronaAttest | Testzentrum S/U Warschauer Strasse",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3935,7 +3935,7 @@
         "location": "Warschauer Pl. 18 10245 Berlin",
         "telephone": null,
         "details_url": "http://www.corona-attest.de/defaultsite",
-        "opening_hours": "Mo 09:00 - 21:00; Tu 09:00 - 21:00; We 09:00 - 21:00; Th 09:00 - 21:00; Fr 09:00 - 21:00; Sa 09:00 - 21:00; Su 09:00 - 21:00; ",
+        "opening_hours": "Mo 09:00 - 21:00; Tu 09:00 - 21:00; We 09:00 - 21:00; Th 09:00 - 21:00; Fr 09:00 - 21:00; Sa 09:00 - 21:00; Su 09:00 - 21:00",
         "title": "CoronaAttest | Testzentrum S/U Warschauer Strasse",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3957,7 +3957,7 @@
         "location": "Jägerstr. 56 10117 Berlin",
         "telephone": null,
         "details_url": "https://www.coronapoint.de/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 10:00 - 18:00; Su 10:00 - 16:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 10:00 - 18:00; Su 10:00 - 16:00",
         "title": "Coronapoint Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -3979,7 +3979,7 @@
         "location": "Schnellerstraße 132-136 12439  Berlin",
         "telephone": null,
         "details_url": "https://coronatest24.org/termin-buchen/#/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:30; Fr 09:00 - 18:00; Sa 09:00 - 14:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:30; Fr 09:00 - 18:00; Sa 09:00 - 14:00",
         "title": "Coronatest 24 bei Mömax",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4001,7 +4001,7 @@
         "location": "Ernst-Augustin-Str. 12 12489 Berlin",
         "telephone": null,
         "details_url": "https://coronatest-adlershof.de/",
-        "opening_hours": "Mo 09:00 - 12:00; Tu 09:00 - 12:00; We 09:00 - 12:00; Th 09:00 - 12:00; Fr 09:00 - 12:00; Sa 09:00 - 12:00; Su 09:00 - 12:00; ",
+        "opening_hours": "Mo 09:00 - 12:00; Tu 09:00 - 12:00; We 09:00 - 12:00; Th 09:00 - 12:00; Fr 09:00 - 12:00; Sa 09:00 - 12:00; Su 09:00 - 12:00",
         "title": "Coronatest-Adlershof",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4023,7 +4023,7 @@
         "location": "Joachim-Karnatz-Allee 47 10557 Berlin",
         "telephone": null,
         "details_url": "https://www.coronatest-berlin.de/",
-        "opening_hours": "Mo 08:30 - 15:30; Tu 08:30 - 15:30; We 08:30 - 15:30; Th 08:30 - 15:30; Fr 08:30 - 15:30; ",
+        "opening_hours": "Mo 08:30 - 15:30; Tu 08:30 - 15:30; We 08:30 - 15:30; Th 08:30 - 15:30; Fr 08:30 - 15:30",
         "title": "Coronatest-Berlin",
         "hints": [
           "PCR-Nachtestung: mit",
@@ -4045,7 +4045,7 @@
         "location": "Friedrichstraße 101 10117 Berlin",
         "telephone": null,
         "details_url": "https://www.coronatest-berlin.de/",
-        "opening_hours": "Mo 07:00 - 16:00; Tu 07:00 - 16:00; We 07:00 - 16:00; Th 07:00 - 16:00; Fr 07:00 - 16:00; ",
+        "opening_hours": "Mo 07:00 - 16:00; Tu 07:00 - 16:00; We 07:00 - 16:00; Th 07:00 - 16:00; Fr 07:00 - 16:00",
         "title": "Coronatest-Berlin Friedrichstraße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4067,7 +4067,7 @@
         "location": "Gehrenseestr. 100 13053 Berlin",
         "telephone": null,
         "details_url": "https://www.zzh-berlin.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00",
         "title": "Coronatest-Berlin Gehrenseestr.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4089,7 +4089,7 @@
         "location": "Joachimsthaler Str. 15 10719 Berlin",
         "telephone": null,
         "details_url": "http://www.coronatest-in-berlin.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Coronatest-in-Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4111,7 +4111,7 @@
         "location": "Albrechtstr. 51 12167 Berlin",
         "telephone": null,
         "details_url": "https://www.markusapotheke-steglitz.de/#",
-        "opening_hours": "Mo 09:00 - 13:00; Tu 09:00 - 13:00; We 09:00 - 13:00; Th 09:00 - 13:00; Fr 09:00 - 13:00; ",
+        "opening_hours": "Mo 09:00 - 13:00; Tu 09:00 - 13:00; We 09:00 - 13:00; Th 09:00 - 13:00; Fr 09:00 - 13:00",
         "title": "Coronatest-Markus-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4133,7 +4133,7 @@
         "location": "Siemensstraße 79/80 12247 Berlin",
         "telephone": null,
         "details_url": "https://www.coronatest-steglitz.com/",
-        "opening_hours": "Mo 07:00 - 17:00; Tu 07:00 - 17:00; We 07:00 - 17:00; Th 07:00 - 17:00; Fr 07:00 - 17:00; Sa 08:00 - 12:00; Su 10:00 - 12:00; ",
+        "opening_hours": "Mo 07:00 - 17:00; Tu 07:00 - 17:00; We 07:00 - 17:00; Th 07:00 - 17:00; Fr 07:00 - 17:00; Sa 08:00 - 12:00; Su 10:00 - 12:00",
         "title": "Coronatest-Steglitz.com",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4155,7 +4155,7 @@
         "location": "Treskowstraße 2 13507 Berlin",
         "telephone": null,
         "details_url": "https://coronatest-tegel.youcanbook.me/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 13:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 13:00",
         "title": "Coronatest-Tegel.Com",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4177,7 +4177,7 @@
         "location": "Fehmarner Str. 25  13353 Berlin",
         "telephone": null,
         "details_url": "https://coronatestung-berlin.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Coronatestung Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4199,7 +4199,7 @@
         "location": "Jägerstr.4 12555 Berlin",
         "telephone": null,
         "details_url": "https://testtermin.de/schuesslerplatz-berlin",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00",
         "title": "Coronazentrum am Schüßlerplatz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4221,7 +4221,7 @@
         "location": "Drontheimer str. 32a  13359 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00",
         "title": "Covid Test 2 go Station Drontheimerstr.32a",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4243,7 +4243,7 @@
         "location": "Tromsoerstr. 6  13359  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00",
         "title": "Covid Test 2 go Station Wedding",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4265,7 +4265,7 @@
         "location": "Knesebeckstraße 35 10623 Berlin",
         "telephone": null,
         "details_url": "https://www.covidtestcenter-berlin.de/termin-buchung/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Covid Test Center Berlin Charlottenburg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4287,7 +4287,7 @@
         "location": "Teplitzer Str. 38 14193 Berlin",
         "telephone": null,
         "details_url": "https://www.covidtestcenter-berlin.de/termin-buchung/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Covid Test Center Berlin Grunewald Schmagendorf",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4309,7 +4309,7 @@
         "location": "Kurfürstendamm 22 10719  Berlin",
         "telephone": null,
         "details_url": "https://www.covidtestcenter-berlin.de/termin-buchung/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Covid Test Center Berlin Kranzler Eck",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4331,7 +4331,7 @@
         "location": "Martin-Buber-Str. 12 14163 Berlin",
         "telephone": null,
         "details_url": "https://www.covidtestcenter-berlin.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Covid Test Center Berlin Martin-Buber-Str.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4353,7 +4353,7 @@
         "location": "Torstraße 170  10115 Berlin",
         "telephone": null,
         "details_url": "https://www.covidtestcenter-berlin.de/termin-buchung/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Covid Test Center Berlin Mitte",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4375,7 +4375,7 @@
         "location": "Grünauerstr. 5 12557 Berlin",
         "telephone": null,
         "details_url": "https://www.covid-testcenter.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00",
         "title": "COVID TestCenter",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4397,7 +4397,7 @@
         "location": "Riemann Str. 16 10961  Berlin",
         "telephone": null,
         "details_url": "https://www.covid-testcenter-berlin.de/",
-        "opening_hours": "Mo 07:00 - 11:00,15:00 - 20:00; Tu 07:00 - 11:00,15:00 - 20:00; We 07:00 - 11:00,15:00 - 20:00; Th 07:00 - 11:00,15:00 - 20:00; Fr 07:00 - 11:00,15:00 - 20:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 07:00 - 11:00,15:00 - 20:00; Tu 07:00 - 11:00,15:00 - 20:00; We 07:00 - 11:00,15:00 - 20:00; Th 07:00 - 11:00,15:00 - 20:00; Fr 07:00 - 11:00,15:00 - 20:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "Covid Testcenter Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4419,7 +4419,7 @@
         "location": "Clayallee 343 14169 Berlin",
         "telephone": null,
         "details_url": "https://www.covidzentrum.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Covid Zentrum Grunewald",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4441,7 +4441,7 @@
         "location": "Lankwitzerstr.19-22 12209 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00",
         "title": "COVID-Freetest",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4463,7 +4463,7 @@
         "location": "Kaiserdamm 99 14057 Berlin",
         "telephone": null,
         "details_url": "http://www.covid19-testzentrum-berlin.de/",
-        "opening_hours": "Mo 09:00 - 18:30; Tu 09:00 - 18:30; We 09:00 - 18:30; Th 09:00 - 18:30; Fr 09:00 - 18:30; Sa 10:00 - 15:00; Su 10:00 - 15:00; ",
+        "opening_hours": "Mo 09:00 - 18:30; Tu 09:00 - 18:30; We 09:00 - 18:30; Th 09:00 - 18:30; Fr 09:00 - 18:30; Sa 10:00 - 15:00; Su 10:00 - 15:00",
         "title": "Covid19-Testzentrum-Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4485,7 +4485,7 @@
         "location": "Buckower Chaussee 100  12277  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 13:30 - 18:00; Tu 13:30 - 18:00; We 13:30 - 18:00; Th 13:30 - 18:00; Fr 13:30 - 18:00; ",
+        "opening_hours": "Mo 13:30 - 18:00; Tu 13:30 - 18:00; We 13:30 - 18:00; Th 13:30 - 18:00; Fr 13:30 - 18:00",
         "title": "Covidschnelltesten Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4507,7 +4507,7 @@
         "location": "Hindenburgdamm 68 12203 Berlin",
         "telephone": null,
         "details_url": "https://berlin-steglitz.covidservicepoint.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 10:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 10:00 - 16:00",
         "title": "Covidservicepoint Berlin-Steglitz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4529,7 +4529,7 @@
         "location": "Landsberger Allee 270 10367 Berlin",
         "telephone": null,
         "details_url": "https://www.covidtest.berlin",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "Covidtest Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4551,7 +4551,7 @@
         "location": "Hermannstr. 12049 Berlin",
         "telephone": null,
         "details_url": "http://ww-service.com/",
-        "opening_hours": "Mo 10:00 - 16:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 10:00 - 16:00; Fr 10:00 - 16:00; Sa 10:00 - 16:00; ",
+        "opening_hours": "Mo 10:00 - 16:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 10:00 - 16:00; Fr 10:00 - 16:00; Sa 10:00 - 16:00",
         "title": "Covidtestcenter Neukölln",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4573,7 +4573,7 @@
         "location": "Bundesallee 78 12161 Berlin",
         "telephone": null,
         "details_url": "http://www.covidzentrum.de",
-        "opening_hours": "Mo 08:00 - 15:00; Tu 08:00 - 15:00; We 08:00 - 15:00; Th 08:00 - 15:00; Fr 08:00 - 15:00; Sa 08:00 - 15:00; Su 08:00 - 15:00; ",
+        "opening_hours": "Mo 08:00 - 15:00; Tu 08:00 - 15:00; We 08:00 - 15:00; Th 08:00 - 15:00; Fr 08:00 - 15:00; Sa 08:00 - 15:00; Su 08:00 - 15:00",
         "title": "Covidzentrum Friedenau",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4595,7 +4595,7 @@
         "location": "Bismarckstr. 35 10627 Berlin",
         "telephone": null,
         "details_url": "https://covidzentrum.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 20:00; Sa 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 20:00; Sa 08:00 - 18:00",
         "title": "CovidZentrum in der Deutschen Oper Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4617,7 +4617,7 @@
         "location": "Turmstraße 25 10559 Berlin",
         "telephone": null,
         "details_url": "http://www.covidzentrum.de",
-        "opening_hours": "Mo 08:00 - 15:00; Tu 08:00 - 15:00; We 08:00 - 15:00; Th 08:00 - 15:00; Fr 08:00 - 15:00; Sa 08:00 - 15:00; Su 08:00 - 15:00; ",
+        "opening_hours": "Mo 08:00 - 15:00; Tu 08:00 - 15:00; We 08:00 - 15:00; Th 08:00 - 15:00; Fr 08:00 - 15:00; Sa 08:00 - 15:00; Su 08:00 - 15:00",
         "title": "Covidzentrum Moabit",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4639,7 +4639,7 @@
         "location": "Prinzessinnenstraße 8-14 10969 Berlin",
         "telephone": null,
         "details_url": "http://www.covidzentrum.de",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Covidzentrum Moritz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4661,7 +4661,7 @@
         "location": "Tamara-Danz-Straße 11 10243 Berlin",
         "telephone": null,
         "details_url": "https://covidzentrum.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00",
         "title": "CovidZentrum.de East Side Mall",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4683,7 +4683,7 @@
         "location": "Curtiusstr. 4 12205 Berlin",
         "telephone": null,
         "details_url": "http://www.curtius-apotheke.berlin/apo/Aktuell/Corona-Schnelltests-741312134",
-        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; ",
+        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00",
         "title": "Curtius Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4705,7 +4705,7 @@
         "location": "Karl-Marx-Str. 231-235 12055  Berlin",
         "telephone": null,
         "details_url": "https://testen.berlin/dafne-nkt",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00",
         "title": "Dafne Apotheke am Neuköllner Tor",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4727,7 +4727,7 @@
         "location": "Hauptstraße 26 10827 Berlin",
         "telephone": null,
         "details_url": "https://testen.berlin/dafne-sb",
-        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 09:30 - 17:00; Su 09:30 - 17:00; ",
+        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 09:30 - 17:00; Su 09:30 - 17:00",
         "title": "Dafne Apotheke Schöneberg",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4749,7 +4749,7 @@
         "location": "Badstraße 32 13357 Berlin",
         "telephone": null,
         "details_url": "https://testen.berlin/dafne-wedding",
-        "opening_hours": "Mo 08:30 - 18:00; Tu 08:30 - 18:00; We 08:30 - 18:00; Th 08:30 - 18:00; Fr 08:30 - 18:00; Sa 09:30 - 14:00; ",
+        "opening_hours": "Mo 08:30 - 18:00; Tu 08:30 - 18:00; We 08:30 - 18:00; Th 08:30 - 18:00; Fr 08:30 - 18:00; Sa 09:30 - 14:00",
         "title": "Dafne Apotheke Wedding",
         "hints": [
           "PCR-Nachtestung: mit",
@@ -4771,7 +4771,7 @@
         "location": "Ansbacher Straße 13 10787 Berlin",
         "telephone": null,
         "details_url": "https://gesund-am-wittenbergplatz.berlin/schnelltest.html",
-        "opening_hours": "Mo 10:00 - 13:00,14:00 - 17:00; Tu 10:00 - 13:00,14:00 - 17:00; We 10:00 - 13:00,14:00 - 17:00; Th 10:00 - 13:00,14:00 - 17:00; Fr 10:00 - 13:00,14:00 - 17:00; ",
+        "opening_hours": "Mo 10:00 - 13:00,14:00 - 17:00; Tu 10:00 - 13:00,14:00 - 17:00; We 10:00 - 13:00,14:00 - 17:00; Th 10:00 - 13:00,14:00 - 17:00; Fr 10:00 - 13:00,14:00 - 17:00",
         "title": "DC DERMACURA",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4793,7 +4793,7 @@
         "location": "Putlitzstr.1 10551  Berlin",
         "telephone": null,
         "details_url": "https://covidtest-sofort.de/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00",
         "title": "Delphin Putlitzstrasse",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4815,7 +4815,7 @@
         "location": "Garbátyplatz 1 13187  Berlin",
         "telephone": "030 499198599",
         "details_url": "http://www.dentalzentrum-pankow.de/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 15:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 15:00",
         "title": "Dentalzentrum Pankow",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4837,7 +4837,7 @@
         "location": "Marzahnerstr. 24B 13053  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 10:00 - 13:00; We 09:00 - 18:00; Th 10:00 - 13:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 10:00 - 13:00; We 09:00 - 18:00; Th 10:00 - 13:00",
         "title": "DeTox",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -4859,7 +4859,7 @@
         "location": "Alt-Blankenburg 22-24 13129 Berlin",
         "telephone": null,
         "details_url": "https://www.dhi24.de",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 10:00 - 14:00; Su 10:00 - 14:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 10:00 - 14:00; Su 10:00 - 14:00",
         "title": "Deutsche Hygiene- und Infektionsschutz GbR",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4881,7 +4881,7 @@
         "location": "Lehmbruckstraße 1 10245 Berlin",
         "telephone": null,
         "details_url": "https://www.covid19center.de/friedrichshain/?sku=covid19berlin",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Deutsches Corona Testzentrum - Friedrichshain",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4903,7 +4903,7 @@
         "location": "Knaackstraße 86 10435 Berlin",
         "telephone": null,
         "details_url": "https://www.covid19center.de/prenzlauer-berg/?sku=covid19berlin",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 09:00 - 18:00",
         "title": "Deutsches Corona Testzentrum - Prenzlauer Berg",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4925,7 +4925,7 @@
         "location": "Schloßstraße 32 12163 Berlin",
         "telephone": null,
         "details_url": "https://www.covid19center.de/steglitz/?sku=covid19berlin",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 18:00",
         "title": "Deutsches Corona Testzentrum - Steglitz",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4947,7 +4947,7 @@
         "location": "Bahnhofstr. 33-38 12555  Berlin",
         "telephone": null,
         "details_url": "https://www.covid19center.de/koepenick/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00",
         "title": "Deutsches Corona Testzentrum Köpenick",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4969,7 +4969,7 @@
         "location": "Rathaus-Center Pankow 1. OG, Breite Str. 20,  13187  Berlin",
         "telephone": null,
         "details_url": "https://www.covid19center.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00",
         "title": "Deutsches Corona Testzentrum Pankow",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -4991,7 +4991,7 @@
         "location": "Schloßstr.116 12163 Berlin",
         "telephone": null,
         "details_url": "https://www.covidoo.de/kunde/diana-apotheke/",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00",
         "title": "Diana Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5013,7 +5013,7 @@
         "location": "Wühlischstr. 57 10245 Berlin",
         "telephone": null,
         "details_url": "https://buchung.dieteststation.de/booking?mess=free",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00",
         "title": "dieTeststation - Boxi Kiez",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5035,7 +5035,7 @@
         "location": "Hellersdorfer Straße 77 - 83 12619 Berlin",
         "telephone": null,
         "details_url": "https://buchung.dieteststation.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "dieTeststation - Spree Center / U Kaulsdorf Nord",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5057,7 +5057,7 @@
         "location": "Bundesallee 186 10717  Berlin",
         "telephone": null,
         "details_url": "https://buchung.dieteststation.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00",
         "title": "dieTeststation - U Berliner Str. / Bundesallee",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5079,7 +5079,7 @@
         "location": "Behrenstr. 28 10117  Berlin",
         "telephone": null,
         "details_url": "https://buchung.dieteststation.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 10:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 10:00 - 16:00",
         "title": "dieTeststation - U Unter den Linden / Friedrichstr.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5101,7 +5101,7 @@
         "location": "Riesaer Str. 102,   12627 Berlin",
         "telephone": null,
         "details_url": "https://buchung.dieteststation.de/",
-        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 06:00 - 20:00; ",
+        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 06:00 - 20:00",
         "title": "dieTeststation Hellersdorf - Riesaer Str.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5123,7 +5123,7 @@
         "location": "Hasenheide 107-108 10967 Berlin",
         "telephone": null,
         "details_url": "https://www.dm.de/",
-        "opening_hours": "Mo 09:00 - 16:30; Tu 09:00 - 16:30; We 09:00 - 16:30; Th 09:00 - 16:30; Fr 09:00 - 16:30; Sa 09:00 - 16:30; ",
+        "opening_hours": "Mo 09:00 - 16:30; Tu 09:00 - 16:30; We 09:00 - 16:30; Th 09:00 - 16:30; Fr 09:00 - 16:30; Sa 09:00 - 16:30",
         "title": "dm-Markt 1162",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5145,7 +5145,7 @@
         "location": "Schloßstraße 10-15 12163  Berlin",
         "telephone": null,
         "details_url": "https://www.dm.de/services/services-im-markt/corona-schnelltest-zentren-613504",
-        "opening_hours": "Mo 09:00 - 16:30; Tu 09:00 - 16:30; We 09:00 - 16:30; Th 09:00 - 16:30; Fr 09:00 - 16:30; Sa 09:00 - 16:30; ",
+        "opening_hours": "Mo 09:00 - 16:30; Tu 09:00 - 16:30; We 09:00 - 16:30; Th 09:00 - 16:30; Fr 09:00 - 16:30; Sa 09:00 - 16:30",
         "title": "dm-Steglitz Boulevard",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5167,7 +5167,7 @@
         "location": "Drakestr. 20 12205 Berlin",
         "telephone": null,
         "details_url": "https://www.drake-apotheke.de/",
-        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; ",
+        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00",
         "title": "Drake Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5189,7 +5189,7 @@
         "location": "Leonorenstr. 89 12247  Berlin",
         "telephone": null,
         "details_url": "https://www.drake-apotheke.de/",
-        "opening_hours": "Mo 08:00 - 17:00; Tu 08:00 - 17:00; We 08:00 - 17:00; Th 08:00 - 17:00; Fr 08:00 - 17:00; ",
+        "opening_hours": "Mo 08:00 - 17:00; Tu 08:00 - 17:00; We 08:00 - 17:00; Th 08:00 - 17:00; Fr 08:00 - 17:00",
         "title": "Drake Apotheke Testzentrum im Ärztehaus",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5211,7 +5211,7 @@
         "location": "Ebersstraße 80A 10827 Berlin",
         "telephone": null,
         "details_url": "http://www.drk-wir-testen-berlin.de",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00",
         "title": "DRK Schöneberg",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5233,7 +5233,7 @@
         "location": "Bachestraße 11 12161 Berlin",
         "telephone": null,
         "details_url": "https://friedenau.probatix.de/de/pick-slot",
-        "opening_hours": "Mo 14:00 - 19:00; Tu 14:00 - 19:00; We 14:00 - 19:00; Th 14:00 - 19:00; Fr 14:00 - 19:00; ",
+        "opening_hours": "Mo 14:00 - 19:00; Tu 14:00 - 19:00; We 14:00 - 19:00; Th 14:00 - 19:00; Fr 14:00 - 19:00",
         "title": "DRK Schöneberg-Wilmersdorf",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5255,7 +5255,7 @@
         "location": "Genthiner Str. 41 10785 Berlin",
         "telephone": null,
         "details_url": "http://www.drk-wir-testen-berlin.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "DRK Teststelle Genthiner Straße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5277,7 +5277,7 @@
         "location": "Chausseestraße 84 10115  Berlin",
         "telephone": null,
         "details_url": "https://drk-berlin.covidservicepoint.de/buchung",
-        "opening_hours": "Th 17:00 - 20:00; Fr 17:00 - 20:00; Sa 08:00 - 16:00; ",
+        "opening_hours": "Th 17:00 - 20:00; Fr 17:00 - 20:00; Sa 08:00 - 16:00",
         "title": "DRK Testzentrum Chausseestraße 84",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5299,7 +5299,7 @@
         "location": "Coldizstr. 27/29 12099 Berlin",
         "telephone": null,
         "details_url": "https://wirtesten.online/corona-teststation",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00",
         "title": "Easy Dienstleitungen Testzentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5321,7 +5321,7 @@
         "location": "Bochumer Str. 16 10555  berlin",
         "telephone": null,
         "details_url": "https://easy-test-mobile.com/Anmeldung/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00",
         "title": "Easy test",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5343,7 +5343,7 @@
         "location": "Schlossstrße 1 12163  Berlin",
         "telephone": "03079016052",
         "details_url": "https://www.forum-steglitz.easyapotheken.de/",
-        "opening_hours": "Mo 11:00 - 17:00; Tu 11:00 - 17:00; We 11:00 - 17:00; Th 11:00 - 17:00; Fr 11:30 - 17:00; Sa 11:00 - 17:00; ",
+        "opening_hours": "Mo 11:00 - 17:00; Tu 11:00 - 17:00; We 11:00 - 17:00; Th 11:00 - 17:00; Fr 11:30 - 17:00; Sa 11:00 - 17:00",
         "title": "Easy-Apotheke im Forum Steglitz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5365,7 +5365,7 @@
         "location": "Rudower Chaussee 12 12489  Berlin",
         "telephone": null,
         "details_url": "https://www.terminland.de/adlershof/",
-        "opening_hours": "Mo 08:00 - 19:30; Tu 08:00 - 19:30; We 08:00 - 19:30; Th 08:00 - 19:30; Fr 08:00 - 19:30; Sa 08:00 - 19:30; ",
+        "opening_hours": "Mo 08:00 - 19:30; Tu 08:00 - 19:30; We 08:00 - 19:30; Th 08:00 - 19:30; Fr 08:00 - 19:30; Sa 08:00 - 19:30",
         "title": "easyApotheke Adlershof",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5387,7 +5387,7 @@
         "location": "Karl-Marx-Str. 66 12043 Berlin",
         "telephone": "030 69572000",
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00",
         "title": "easyApotheke Neukölln Arcaden",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5409,7 +5409,7 @@
         "location": "Residenzstrasse 33 13409 Berlin",
         "telephone": null,
         "details_url": "https://wirtesten.online/easyapotheke-residenzstr",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 09:00 - 15:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 09:00 - 15:00",
         "title": "easyApotheke Residenzstrasse Testzentrum",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5431,7 +5431,7 @@
         "location": "Pichelsdorferstr. 146  13595  Berlin",
         "telephone": null,
         "details_url": "https://easytest-spandau.business.site",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00",
         "title": "Easytest spandau",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5453,7 +5453,7 @@
         "location": "Lankwitzer Str. 19-24 12209  Berlin",
         "telephone": null,
         "details_url": "https://deintermin.e-app.eu/termin/elixia-lichterfelde",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "ELIXIA Testzentrum Lichterfelde",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5475,7 +5475,7 @@
         "location": "Prager Platz 1-3 10779 Berlin",
         "telephone": null,
         "details_url": "https://deintermin.e-app.eu/termin/elixia-pragerplatz",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "ELIXIA Testzentrum Prager Platz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5497,7 +5497,7 @@
         "location": "Sonnenallee 225 12057 Berlin",
         "telephone": null,
         "details_url": "https://testzentrum.estrel.com/",
-        "opening_hours": "Mo 07:00 - 17:00; Tu 07:00 - 17:00; We 07:00 - 17:00; Th 07:00 - 17:00; Fr 07:00 - 17:00; Sa 07:00 - 17:00; Su 07:00 - 17:00; ",
+        "opening_hours": "Mo 07:00 - 17:00; Tu 07:00 - 17:00; We 07:00 - 17:00; Th 07:00 - 17:00; Fr 07:00 - 17:00; Sa 07:00 - 17:00; Su 07:00 - 17:00",
         "title": "Estrel Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5519,7 +5519,7 @@
         "location": "Herzbergstraße 79 10365 Berlin",
         "telephone": null,
         "details_url": "https://www.keh-berlin.de/de/coronavirus",
-        "opening_hours": "Mo 08:30 - 16:00; We 08:30 - 16:00; Fr 08:30 - 16:00; ",
+        "opening_hours": "Mo 08:30 - 16:00; We 08:30 - 16:00; Fr 08:30 - 16:00",
         "title": "Evangelisches Krankenhaus Königin-Elisabeth Herzberge",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5541,7 +5541,7 @@
         "location": "Reichenhallerstraße 63 14199 Berlin",
         "telephone": null,
         "details_url": "https://app.clickandtest.de/#/pages/center/FundFschnelltest",
-        "opening_hours": "Sa 09:00 - 14:00; ",
+        "opening_hours": "Sa 09:00 - 14:00",
         "title": "F&F Schnelltest",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5563,7 +5563,7 @@
         "location": "Uhlandstrasse 131 10717 Berlin",
         "telephone": null,
         "details_url": "http://face-sculpt-clinic.de/",
-        "opening_hours": "Mo 10:00 - 17:00; Tu 10:00 - 17:00; We 10:00 - 17:00; Th 10:00 - 17:00; Fr 10:00 - 17:00; Sa 10:00 - 17:00; Su 10:00 - 17:00; ",
+        "opening_hours": "Mo 10:00 - 17:00; Tu 10:00 - 17:00; We 10:00 - 17:00; Th 10:00 - 17:00; Fr 10:00 - 17:00; Sa 10:00 - 17:00; Su 10:00 - 17:00",
         "title": "FaceSculptClinic",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5585,7 +5585,7 @@
         "location": "Weser str.213  12047 Berlin",
         "telephone": "030 69533199",
         "details_url": "https://fahrschulemetropol.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00",
         "title": "Fahrschule Metropol",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5607,7 +5607,7 @@
         "location": "Kiautschoustraße 12A 13353 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Fast & Safe Kiautschoustraße",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5629,7 +5629,7 @@
         "location": "Am Zwingraben 2 10178 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Fast & Save Am Zwingraben",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5651,7 +5651,7 @@
         "location": "Hauptstrasse 131 10827 Berlin",
         "telephone": null,
         "details_url": "https://app.no-q.info/feurig-apotheke/checkins#/557/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 14:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 14:00",
         "title": "Feurig Apotheke",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5673,7 +5673,7 @@
         "location": "Markt 2-3 13597 Berlin",
         "telephone": null,
         "details_url": "https://app.no-q.info/fontane-apotheke/checkins#",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00",
         "title": "Fontane Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5695,7 +5695,7 @@
         "location": "Uhlandstr. 28 10719 Berlin",
         "telephone": null,
         "details_url": "https://app.no-q.info/fontane-apotheke/checkins#",
-        "opening_hours": "Mo 08:30 - 19:30; Tu 08:30 - 19:30; We 08:30 - 19:30; Th 08:30 - 19:30; Fr 08:30 - 19:30; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 08:30 - 19:30; Tu 08:30 - 19:30; We 08:30 - 19:30; Th 08:30 - 19:30; Fr 08:30 - 19:30; Sa 09:00 - 18:00",
         "title": "Fontane Apotheke Uhlandstr.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5717,7 +5717,7 @@
         "location": "Karl-Marx-Str. 80 12043 Berlin",
         "telephone": null,
         "details_url": "https://www.forum-apotheke.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00",
         "title": "Forum Apotheke am Rathaus Neukölln",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5739,7 +5739,7 @@
         "location": "Rosenthaler Weg 46 13127  Berlin",
         "telephone": null,
         "details_url": "https://www.coronatest-in-berlin.de/buchholz/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Französisch Buchholz Testzentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5761,7 +5761,7 @@
         "location": "Habelschwerdter Alle 45 14195 Berlin",
         "telephone": null,
         "details_url": "https://covid-testzentrum.net/berlin-fu/",
-        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; ",
+        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00",
         "title": "Freie Universität Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -5783,7 +5783,7 @@
         "location": "Glinkastr. 4 10117 Berlin",
         "telephone": null,
         "details_url": "https://app.no-q.info/friedrichstadt-apotheke/checkins",
-        "opening_hours": "Mo 10:00 - 17:00; Tu 10:00 - 17:00; We 10:00 - 17:00; Th 10:00 - 17:00; Fr 10:00 - 17:00; ",
+        "opening_hours": "Mo 10:00 - 17:00; Tu 10:00 - 17:00; We 10:00 - 17:00; Th 10:00 - 17:00; Fr 10:00 - 17:00",
         "title": "Friedrichstadt-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5805,7 +5805,7 @@
         "location": "Luckenwalderstr. 3 10963  Berlin",
         "telephone": "0176 97913135",
         "details_url": "http://www.kuehlhaus-berlin.com/de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "FUTURE TEST BERLIN",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5827,7 +5827,7 @@
         "location": "Teltower Damm 31 14169 Berlin",
         "telephone": null,
         "details_url": "https://www.adlerapoberlin.de/",
-        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30; ",
+        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30",
         "title": "Gartenteststation",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5849,7 +5849,7 @@
         "location": "Sonnenallee 6 12047 Berlin",
         "telephone": null,
         "details_url": "https://schnell.coronatest.de",
-        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 06:00 - 20:00; ",
+        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 06:00 - 20:00",
         "title": "Gastmannschaft GmbH Sonnenallee",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5871,7 +5871,7 @@
         "location": "Tempelhofer Ufer 14 10963 Berlin",
         "telephone": null,
         "details_url": "https://schnell.coronatest.de",
-        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 06:00 - 20:00; ",
+        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 06:00 - 20:00",
         "title": "Gastmannschaft GmbH Tempelhofer Ufer",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5893,7 +5893,7 @@
         "location": "Walter-Friedrich-Str. 6 13125 Berlin",
         "telephone": null,
         "details_url": "https://ginkgo-apotheke-berlin.de/",
-        "opening_hours": "Tu 08:00 - 10:00; Th 15:00 - 17:00; Sa 10:00 - 14:00; ",
+        "opening_hours": "Tu 08:00 - 10:00; Th 15:00 - 17:00; Sa 10:00 - 14:00",
         "title": "Ginkgo-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5915,7 +5915,7 @@
         "location": "Joachim-Friedrich-Straße 24 10711 Berlin",
         "telephone": null,
         "details_url": "https://joachimfriedrich.youcanbook.me",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 14:00",
         "title": "Gratis Coronaschnelltest Halensee",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5937,7 +5937,7 @@
         "location": "Markstr. 25 13409 Berlin",
         "telephone": null,
         "details_url": "https://marktstrasse25.youcanbook.me",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 14:00",
         "title": "Gratis Coronatest Reinickendorf/Wedding",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5959,7 +5959,7 @@
         "location": "Bahnhofstr. 27 12305 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "Gratis covid 19 schnelltest Station",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -5981,7 +5981,7 @@
         "location": "Krumme Straße  58 10627 Berlin",
         "telephone": null,
         "details_url": "https://krummestrasse.youcanbook.me/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 14:00",
         "title": "Gratis-Coronatest-Charlottenburg.de",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6003,7 +6003,7 @@
         "location": "Steglitzer Damm 76 12169 Berlin",
         "telephone": null,
         "details_url": "https://steglitzerdamm76.youcanbook.me/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 14:00",
         "title": "Gratis-Coronatest-Steglitz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6025,7 +6025,7 @@
         "location": "Siemensstr.2 12247 Berlin",
         "telephone": null,
         "details_url": "https://grosscurthsapotheke.youcanbook.me/",
-        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 08:30 - 19:00; ",
+        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 08:30 - 19:00",
         "title": "Grosscurths Apotheke",
         "hints": [
           "PCR-Nachtestung: mit",
@@ -6047,7 +6047,7 @@
         "location": "Cicerostr. 16a 10709  Berlin",
         "telephone": null,
         "details_url": "http://www.gullivers.de/",
-        "opening_hours": "Mo 06:00 - 18:00; Tu 06:00 - 18:00; We 06:00 - 18:00; Th 06:00 - 18:00; Fr 06:00 - 18:00; Sa 06:00 - 18:00; Su 06:00 - 18:00; ",
+        "opening_hours": "Mo 06:00 - 18:00; Tu 06:00 - 18:00; We 06:00 - 18:00; Th 06:00 - 18:00; Fr 06:00 - 18:00; Sa 06:00 - 18:00; Su 06:00 - 18:00",
         "title": "Gullivers Testzentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6069,7 +6069,7 @@
         "location": "Weißenhöher Straße 88-108 12683  Berlin",
         "telephone": null,
         "details_url": "https://www.schnell-schneller-coronatest.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00",
         "title": "Handelszentrum Berlin-Biesdorf",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6091,7 +6091,7 @@
         "location": "Klosterstrasse 34/35 13581 Berlin",
         "telephone": null,
         "details_url": "https://hauptstadtapotheke.de/",
-        "opening_hours": "Mo 10:00 - 12:30; Th 10:00 - 12:30; Fr 10:00 - 12:30; ",
+        "opening_hours": "Mo 10:00 - 12:30; Th 10:00 - 12:30; Fr 10:00 - 12:30",
         "title": "Hauptstadt Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6113,7 +6113,7 @@
         "location": "Wasgenstraße 75 14129 Berlin",
         "telephone": null,
         "details_url": "https://corona-schnelltest-haus14.ticket.io/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00",
         "title": "Haus 14 im Stundentendorf Schlachtensee",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6135,7 +6135,7 @@
         "location": "Zabel-Krüger-Damm 121 13469  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 07:00 - 14:00; Tu 07:00 - 14:00; We 07:00 - 14:00; Th 07:00 - 14:00; Fr 07:00 - 14:00; ",
+        "opening_hours": "Mo 07:00 - 14:00; Tu 07:00 - 14:00; We 07:00 - 14:00; Th 07:00 - 14:00; Fr 07:00 - 14:00",
         "title": "Hausarztpraxis Leimer-Lipke & Bajorat-Kollegger",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6157,7 +6157,7 @@
         "location": "Sakrower Landstr. 6 14089 Berlin",
         "telephone": null,
         "details_url": "https://havelland-apotheke-berlin.apotermin.online",
-        "opening_hours": "Mo 09:00 - 11:00; Tu 09:00 - 11:00; We 09:00 - 11:00; Th 09:00 - 11:00; Fr 09:00 - 11:00; ",
+        "opening_hours": "Mo 09:00 - 11:00; Tu 09:00 - 11:00; We 09:00 - 11:00; Th 09:00 - 11:00; Fr 09:00 - 11:00",
         "title": "Havelland-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6179,7 +6179,7 @@
         "location": "Oranienburgerstraße 86 13437 Berlin",
         "telephone": null,
         "details_url": "http://www.hno-daemmig.de",
-        "opening_hours": "Mo 10:00 - 13:00; Tu 10:00 - 13:00; We 10:00 - 13:00; Th 10:00 - 13:00; Fr 09:00 - 12:00; ",
+        "opening_hours": "Mo 10:00 - 13:00; Tu 10:00 - 13:00; We 10:00 - 13:00; Th 10:00 - 13:00; Fr 09:00 - 12:00",
         "title": "HNO Praxis Annett Dämmig",
         "hints": [
           "PCR-Nachtestung: mit",
@@ -6201,7 +6201,7 @@
         "location": "Karl-Liebknecht-Str. 30 10178 Berlin",
         "telephone": null,
         "details_url": "https://www.covid-testzentrum.de/hofbraeuhaus-ber",
-        "opening_hours": "Mo 00:00 - 23:30; Tu 00:00 - 23:30; We 00:00 - 23:30; Th 00:00 - 23:30; Fr 00:00 - 23:30; Sa 00:00 - 23:30; Su 00:00 - 23:30; ",
+        "opening_hours": "Mo 00:00 - 23:30; Tu 00:00 - 23:30; We 00:00 - 23:30; Th 00:00 - 23:30; Fr 00:00 - 23:30; Sa 00:00 - 23:30; Su 00:00 - 23:30",
         "title": "Hofbräu Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6223,7 +6223,7 @@
         "location": "Haubachstraße 22 10585 Berlin",
         "telephone": null,
         "details_url": "https://haubach-hotel.de/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00",
         "title": "Hotel Haubach",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6245,7 +6245,7 @@
         "location": "Rudower Chaussee 24 12489  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00",
         "title": "HU Adlershof",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6267,7 +6267,7 @@
         "location": "Unter den Linden 6 10117 Berlin",
         "telephone": null,
         "details_url": "https://www.covid-testzentrum.de/huberlin",
-        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; ",
+        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00",
         "title": "HU Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6289,7 +6289,7 @@
         "location": "Salzufer 13/14 10587 Berlin",
         "telephone": null,
         "details_url": "https://www.covisa.de/",
-        "opening_hours": "Mo 10:00 - 16:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 10:00 - 16:00; Fr 10:00 - 16:00; ",
+        "opening_hours": "Mo 10:00 - 16:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 10:00 - 16:00; Fr 10:00 - 16:00",
         "title": "Hubertus Apotheke am Salzufer",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6311,7 +6311,7 @@
         "location": "Gewerbehof 10  13597  Berlin",
         "telephone": null,
         "details_url": "https://testedichschnell.de/berlin-spandau/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00",
         "title": "Ikea Schnelltest-Station Spandau",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6333,7 +6333,7 @@
         "location": "Ferdinandstrasse 32 12209  Berlin",
         "telephone": null,
         "details_url": "www.imzentrum.net",
-        "opening_hours": "Mo 08:00 - 17:30; Tu 08:00 - 17:30; We 08:00 - 17:30; Th 08:00 - 17:30; Fr 08:00 - 16:00; Sa 08:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 17:30; Tu 08:00 - 17:30; We 08:00 - 17:30; Th 08:00 - 17:30; Fr 08:00 - 16:00; Sa 08:00 - 14:00",
         "title": "Imzentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6355,7 +6355,7 @@
         "location": "Neue Grünstrasse 2 10179 Berlin",
         "telephone": null,
         "details_url": "https://www.timify.com/de-de/profile/infini-institut/?v=4",
-        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 16:00; ",
+        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 16:00",
         "title": "INFINI Institut Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6377,7 +6377,7 @@
         "location": "Lortzingstr. 42 13355 Berlin",
         "telephone": "030 46404615",
         "details_url": "https://jasmin-apotheke-berlin.apotermin.online/",
-        "opening_hours": "Mo 08:30 - 18:30; Tu 08:30 - 18:30; We 08:30 - 18:30; Th 08:30 - 18:30; Fr 08:30 - 18:30; Sa 08:30 - 18:30; ",
+        "opening_hours": "Mo 08:30 - 18:30; Tu 08:30 - 18:30; We 08:30 - 18:30; Th 08:30 - 18:30; Fr 08:30 - 18:30; Sa 08:30 - 18:30",
         "title": "Jasmin Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6399,7 +6399,7 @@
         "location": "Märkische Spitze 15 12681 Berlin",
         "telephone": null,
         "details_url": "https://www.johanniter.de/testen-berlin",
-        "opening_hours": "Mo 07:00 - 18:30; Tu 07:00 - 18:30; We 07:00 - 18:30; Th 07:00 - 18:30; Fr 07:00 - 18:30; Sa 08:00 - 18:30; ",
+        "opening_hours": "Mo 07:00 - 18:30; Tu 07:00 - 18:30; We 07:00 - 18:30; Th 07:00 - 18:30; Fr 07:00 - 18:30; Sa 08:00 - 18:30",
         "title": "Johanniter / Hornbach Berlin-Marzahn",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6421,7 +6421,7 @@
         "location": "Fromet-und-Moses- Mendelssohn-Platz 1 10969 Berlin",
         "telephone": null,
         "details_url": "https://schnell.coronatest.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00",
         "title": "Jüdisches Museum",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6443,7 +6443,7 @@
         "location": "Warburgzeile 2 10585 Berlin",
         "telephone": null,
         "details_url": "https://www.k-medical.de/testzentrum/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00",
         "title": "K-Medical",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6465,7 +6465,7 @@
         "location": "Görlitzer Str. 38 10997 Berlin",
         "telephone": null,
         "details_url": "https://www.k-medical.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 09:00 - 18:00",
         "title": "K-Medical Kreuzberg Görlitzer Str.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6487,7 +6487,7 @@
         "location": "Ohmstr. 1 10179 Berlin",
         "telephone": null,
         "details_url": "https://www.k-medical.de/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00",
         "title": "K-Medical Mitte",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6509,7 +6509,7 @@
         "location": "Kurstr. 20 13585 Berlin",
         "telephone": null,
         "details_url": "https://www.k-medical.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "K-Medical Spandau",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6531,7 +6531,7 @@
         "location": "Sonnenallee 70 12045 Berlin",
         "telephone": null,
         "details_url": "https://www.kalimat.de/test-to-go",
-        "opening_hours": "Mo 06:00 - 22:00; Tu 06:00 - 22:00; We 06:00 - 22:00; Th 06:00 - 22:00; Fr 06:00 - 22:00; Sa 06:00 - 22:00; Su 06:00 - 22:00; ",
+        "opening_hours": "Mo 06:00 - 22:00; Tu 06:00 - 22:00; We 06:00 - 22:00; Th 06:00 - 22:00; Fr 06:00 - 22:00; Sa 06:00 - 22:00; Su 06:00 - 22:00",
         "title": "KALIMAT",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6553,7 +6553,7 @@
         "location": "Wilmersdorfer Straße 118 10627 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00",
         "title": "Karstadt Berlin Charlottenburg",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6575,7 +6575,7 @@
         "location": "Schloßstr. 7-10  12163  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00",
         "title": "Karstadt | Schloßstraße | Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6597,7 +6597,7 @@
         "location": "Frankfurter Allee 113-117 10365  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00",
         "title": "Kaufhof Ringcenter Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6619,7 +6619,7 @@
         "location": "Reichsstraße 108 14052 Berlin",
         "telephone": "0151 65771376",
         "details_url": "https://www.kinderarztpraxis-am-theo.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00",
         "title": "Kinder- und Familien-Testzentrum am Theo",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6641,7 +6641,7 @@
         "location": "Prerower Platz 4 13051 Berlin",
         "telephone": "030 9298032",
         "details_url": "http://www.kinderarzt-dr-lueder.de/",
-        "opening_hours": "Mo 08:00 - 12:00,15:00 - 17:30; Tu 08:00 - 12:00; We 08:00 - 12:00; Th 08:00 - 12:00,15:00 - 17:30; Fr 08:00 - 12:00; ",
+        "opening_hours": "Mo 08:00 - 12:00,15:00 - 17:30; Tu 08:00 - 12:00; We 08:00 - 12:00; Th 08:00 - 12:00,15:00 - 17:30; Fr 08:00 - 12:00",
         "title": "Kinderarztpraxis Dr. Steffen Lüder",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6663,7 +6663,7 @@
         "location": "Krokusstrasse 7 12357  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 21:00; Tu 09:00 - 21:00; We 09:00 - 21:00; Th 09:00 - 21:00; Fr 09:00 - 21:00; Sa 09:00 - 21:00; Su 09:00 - 21:00; ",
+        "opening_hours": "Mo 09:00 - 21:00; Tu 09:00 - 21:00; We 09:00 - 21:00; Th 09:00 - 21:00; Fr 09:00 - 21:00; Sa 09:00 - 21:00; Su 09:00 - 21:00",
         "title": "KomMitTest Krokussstr.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6685,7 +6685,7 @@
         "location": "Königstr. 40 14109  Berlin",
         "telephone": null,
         "details_url": "https://corona-schnelltest-koenig19.ticket.io/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "König 19",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6707,7 +6707,7 @@
         "location": "Lindenallee 28 14050 Berlin",
         "telephone": null,
         "details_url": "https://www.kranich-apotheke-berlin.de/website/",
-        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 08:30 - 14:00; ",
+        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 08:30 - 14:00",
         "title": "Kranich-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6729,7 +6729,7 @@
         "location": "Argentinische Allee 40 14163 Berlin",
         "telephone": null,
         "details_url": "https://www.krankenhaus-waldfriede.de/",
-        "opening_hours": "Mo 14:00 - 18:00; Tu 14:00 - 18:00; We 14:00 - 18:00; Th 14:00 - 18:00; Fr 14:00 - 18:00; Sa 09:00 - 13:00; ",
+        "opening_hours": "Mo 14:00 - 18:00; Tu 14:00 - 18:00; We 14:00 - 18:00; Th 14:00 - 18:00; Fr 14:00 - 18:00; Sa 09:00 - 13:00",
         "title": "Krankenhaus Waldfriede",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6751,7 +6751,7 @@
         "location": "Schloßstraße 82 12165 Berlin",
         "telephone": "030 7916028",
         "details_url": "http://www.kreisel-apotheke.de/",
-        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; Sa 09:00 - 18:00",
         "title": "Kreisel-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6773,7 +6773,7 @@
         "location": "Mehringdamm 69 10961 Berlin",
         "telephone": null,
         "details_url": "https://www.kreuzberg-apo.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 09:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 09:00 - 14:00",
         "title": "Kreuzberg-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6795,7 +6795,7 @@
         "location": "Fischerhüttenstraße 64 14163 Berlin",
         "telephone": null,
         "details_url": "https://www.krumme-lanke-apotheke.de/website/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 13:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 13:00",
         "title": "Krumme Lanke Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6817,7 +6817,7 @@
         "location": "Lietzenburgerstrasse 29 10789 Berlin",
         "telephone": null,
         "details_url": "https://kudammtest.de/shop",
-        "opening_hours": "Mo 00:00 - 23:59; Tu 00:00 - 23:59; We 00:00 - 23:00; Th 00:00 - 23:59; Fr 00:00 - 23:59; Sa 00:00 - 23:59; Su 00:00 - 23:59; ",
+        "opening_hours": "Mo 00:00 - 23:59; Tu 00:00 - 23:59; We 00:00 - 23:00; Th 00:00 - 23:59; Fr 00:00 - 23:59; Sa 00:00 - 23:59; Su 00:00 - 23:59",
         "title": "Kudammtest",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6839,7 +6839,7 @@
         "location": "Reinickendorfer Straße 11-12 13347 Berlin",
         "telephone": null,
         "details_url": "http://www.lessing-apotheke-berlin.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 14:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 14:00",
         "title": "Lessing-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6861,7 +6861,7 @@
         "location": "Heinsestr. 32-34 13467 Berlin",
         "telephone": "030 40508240",
         "details_url": "https://schnelltest.apomondo.online/#/termine/48cdc526-e2ab-42ee-b588-d0c751f9eadc",
-        "opening_hours": "Mo 08:30 - 18:30; Tu 08:30 - 18:30; We 08:30 - 18:30; Th 08:30 - 18:30; Fr 08:30 - 18:30; Sa 08:30 - 18:30; ",
+        "opening_hours": "Mo 08:30 - 18:30; Tu 08:30 - 18:30; We 08:30 - 18:30; Th 08:30 - 18:30; Fr 08:30 - 18:30; Sa 08:30 - 18:30",
         "title": "Leuchtturm Apotheke",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -6883,7 +6883,7 @@
         "location": "Ruppinerstr. 10 10115 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Levan TS Teststation",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6905,7 +6905,7 @@
         "location": "Knesebeckstr. 93 10623 Berlin",
         "telephone": null,
         "details_url": "https://covisa.de/covisacenter",
-        "opening_hours": "Mo 14:00 - 15:30; Tu 14:00 - 15:30; We 14:00 - 15:30; Th 14:00 - 15:30; Fr 14:00 - 15:30; Sa 14:00 - 15:30; ",
+        "opening_hours": "Mo 14:00 - 15:30; Tu 14:00 - 15:30; We 14:00 - 15:30; Th 14:00 - 15:30; Fr 14:00 - 15:30; Sa 14:00 - 15:30",
         "title": "Lilas Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6927,7 +6927,7 @@
         "location": "Buchholzer Str. 54 13156 Berlin",
         "telephone": null,
         "details_url": "https://www.corona-schnelltest.center/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00",
         "title": "Lima Schnelltest-Station Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6949,7 +6949,7 @@
         "location": "Alt-Lietzow 33 10587 Berlin",
         "telephone": null,
         "details_url": "http://www.malteser.de/",
-        "opening_hours": "Mo 08:00 - 13:00; Tu 08:00 - 13:00; We 08:00 - 13:00; Th 08:00 - 13:00; Fr 08:00 - 13:00; ",
+        "opening_hours": "Mo 08:00 - 13:00; Tu 08:00 - 13:00; We 08:00 - 13:00; Th 08:00 - 13:00; Fr 08:00 - 13:00",
         "title": "Malteser Hilfsdienst - Corona Schnelltest",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6971,7 +6971,7 @@
         "location": "Breite Str. 1 14199  Berlin",
         "telephone": "030 28624953",
         "details_url": "https://www.24seven-berlin.de/",
-        "opening_hours": "Mo 12:00 - 18:00; Tu 12:00 - 18:00; We 12:00 - 18:00; Th 12:00 - 18:00; Fr 12:00 - 18:00; Sa 12:00 - 18:00; Su 12:00 - 18:00; ",
+        "opening_hours": "Mo 12:00 - 18:00; Tu 12:00 - 18:00; We 12:00 - 18:00; Th 12:00 - 18:00; Fr 12:00 - 18:00; Sa 12:00 - 18:00; Su 12:00 - 18:00",
         "title": "Manico",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -6993,7 +6993,7 @@
         "location": "Brunsbütteler Damm 271 13591 Berlin",
         "telephone": null,
         "details_url": "https://covisa.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00",
         "title": "Mariannen Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7015,7 +7015,7 @@
         "location": "Ruthstraße 12 12247 Berlin",
         "telephone": null,
         "details_url": "http://www.marien-apotheke-berlin.de",
-        "opening_hours": "Mo 09:30 - 14:30; Tu 09:30 - 14:30; We 09:30 - 14:30; Th 09:30 - 14:30; Fr 09:30 - 14:30; Sa 09:00 - 13:00; ",
+        "opening_hours": "Mo 09:30 - 14:30; Tu 09:30 - 14:30; We 09:30 - 14:30; Th 09:30 - 14:30; Fr 09:30 - 14:30; Sa 09:00 - 13:00",
         "title": "Marien Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7037,7 +7037,7 @@
         "location": "Kottbusser Damm 86 10967 Berlin",
         "telephone": null,
         "details_url": "https://www.mauritius-apotheke-berlin.de/website/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00",
         "title": "Mauritius Apotheke",
         "hints": [
           "PCR-Nachtestung: mit",
@@ -7059,7 +7059,7 @@
         "location": "Brunsbütteler Damm108 13581 Berlin",
         "telephone": null,
         "details_url": "https://www.mauritius-apotheke-berlin.de/website/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00",
         "title": "Mauritius Apotheke Testzentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7081,7 +7081,7 @@
         "location": "Finowstr. 5  12054  Berlin",
         "telephone": "030 6913071",
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00",
         "title": "Mauritius Teststation Finowstr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7103,7 +7103,7 @@
         "location": "Werbellinstrasse 5  12053 Berlin",
         "telephone": "030 6913071",
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00",
         "title": "Mauritius Teststation Werbellinstr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7125,7 +7125,7 @@
         "location": "Flughafenstr. 43 12053  Berlin",
         "telephone": null,
         "details_url": "https://mauritius-apotheke-berlin.de/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00",
         "title": "Mauritius Zentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7147,7 +7147,7 @@
         "location": "Kantstr. 15a (Innenhof) 10623 Berlin",
         "telephone": null,
         "details_url": "http://md-coronatest.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00",
         "title": "MD Corona Test Kantstraße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7169,7 +7169,7 @@
         "location": "Hermannstr. 158a  12051  Berlin",
         "telephone": null,
         "details_url": "https://www.coronatest-eu.com/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 20:00",
         "title": "Medican GmbH Herrmannstr. ",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7191,7 +7191,7 @@
         "location": "Rathenower Straße 63 10559 Berlin",
         "telephone": null,
         "details_url": "http://www.coronatest-eu.com/",
-        "opening_hours": "Mo 06:00 - 21:00; Tu 06:00 - 21:00; We 06:00 - 21:00; Th 06:00 - 21:00; Fr 06:00 - 21:00; Sa 06:00 - 21:00; Su 09:00 - 20:00; ",
+        "opening_hours": "Mo 06:00 - 21:00; Tu 06:00 - 21:00; We 06:00 - 21:00; Th 06:00 - 21:00; Fr 06:00 - 21:00; Sa 06:00 - 21:00; Su 09:00 - 20:00",
         "title": "Medican Testzentrum",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -7213,7 +7213,7 @@
         "location": "Am Stichkanal 11 14167  Berlin",
         "telephone": null,
         "details_url": "https://www.coronatest-eu.com/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 16:00",
         "title": "Medican Testzentrum Am Stichkanal",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7235,7 +7235,7 @@
         "location": "Bundesallee 18 10717  Berlin",
         "telephone": null,
         "details_url": "https://www.coronatest-eu.com/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 16:00",
         "title": "Medican Testzentrum Bundesallee",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7257,7 +7257,7 @@
         "location": "Leibnizstr. 72 10625 Berlin",
         "telephone": null,
         "details_url": "https://medicare-charlottenburg.ticket.io/?onlyTag=buergertestung",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 10:00 - 16:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 10:00 - 16:00; Su 10:00 - 18:00",
         "title": "Medicare Testzentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7279,7 +7279,7 @@
         "location": "Wohlrabedamm 34    13629  Berlin",
         "telephone": null,
         "details_url": "https://covid-testzentrum.net/berlin-siemensstadt/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "Medicare Tetzentrum Berlin Siemensstadt",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7301,7 +7301,7 @@
         "location": "Rosenthaler Str. 40 10178 Berlin",
         "telephone": null,
         "details_url": "http://www.mediosapotheke.de/corona-testzentrum",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00",
         "title": "MediosApotheke Testzentrum im Hackesche Höfe Kino",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7323,7 +7323,7 @@
         "location": "Oranienstr.7 10997 Berlin",
         "telephone": "030 70071727",
         "details_url": "https://www.eick-apotheke.de/website/",
-        "opening_hours": "Mo 11:00 - 17:00; Tu 11:00 - 17:00; We 11:00 - 17:00; Th 11:00 - 17:00; Fr 11:00 - 17:00; Sa 11:00 - 17:00; ",
+        "opening_hours": "Mo 11:00 - 17:00; Tu 11:00 - 17:00; We 11:00 - 17:00; Th 11:00 - 17:00; Fr 11:00 - 17:00; Sa 11:00 - 17:00",
         "title": "Mehmet Geyik",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7345,7 +7345,7 @@
         "location": "Wriezener Karree 15 10243 Berlin",
         "telephone": null,
         "details_url": "https://berlin.meincoronaschnelltest.de/corona-test-buchen/berlin/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Mein Corona Schnelltest",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7367,7 +7367,7 @@
         "location": "Marzahner Promenade 1A 12679 Berlin",
         "telephone": null,
         "details_url": "https://www.meincoronaschnelltest.de/",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00",
         "title": "Mein Corona Schnelltest - EASTGATE Center",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7389,7 +7389,7 @@
         "location": "Badstraße 4 13357 Berlin",
         "telephone": null,
         "details_url": "https://www.meincoronaschnelltest.de/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00",
         "title": "Mein Corona Schnelltest - Gesundbrunnen Center",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7411,7 +7411,7 @@
         "location": "Am Borsigturm 2 13507 Berlin",
         "telephone": null,
         "details_url": "https://www.meincoronaschnelltest.de/",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00",
         "title": "Mein Corona Schnelltest - Hallen am Borsigturm",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7433,7 +7433,7 @@
         "location": "Prerower Platz 1 13051  Berlin",
         "telephone": null,
         "details_url": "https://www.meincoronaschnelltest.de/",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; Su 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; Su 10:00 - 19:00",
         "title": "Mein Corona Schnelltest - Linden-Center",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7455,7 +7455,7 @@
         "location": "Frankfurter Allee 113-117,  10365  Berlin",
         "telephone": null,
         "details_url": "https://www.meincoronaschnelltest.de/",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00",
         "title": "Mein Corona Schnelltest - Ring Center II",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7477,7 +7477,7 @@
         "location": "Tempelhofer Damm 227 12099 Berlin",
         "telephone": null,
         "details_url": "https://www.meincoronaschnelltest.de/",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00",
         "title": "Mein Corona Schnelltest - Tempelhofer Hafen",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7499,7 +7499,7 @@
         "location": "Brunnenstraße 197-198 10119  Berlin",
         "telephone": null,
         "details_url": "https://www.diecoronatester.de/",
-        "opening_hours": "Mo 07:00 - 21:00; Tu 07:00 - 21:00; We 07:00 - 21:00; Th 07:00 - 21:00; Fr 07:00 - 21:00; Sa 09:00 - 21:00; Su 09:00 - 21:00; ",
+        "opening_hours": "Mo 07:00 - 21:00; Tu 07:00 - 21:00; We 07:00 - 21:00; Th 07:00 - 21:00; Fr 07:00 - 21:00; Sa 09:00 - 21:00; Su 09:00 - 21:00",
         "title": "Mein Haus am See",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7521,7 +7521,7 @@
         "location": "Landsberger Allee 320 10365 Berlin",
         "telephone": null,
         "details_url": "http://www.sicher-offen.com/",
-        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30; Su 09:30 - 18:30; ",
+        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30; Su 09:30 - 18:30",
         "title": "Möbel Höffner Berlin Lichtenberg Testcenter",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7543,7 +7543,7 @@
         "location": "Saarbrücker Str. 24 10405 Berlin",
         "telephone": null,
         "details_url": "https://biketaxi.de/berlin/corona-schnelltest.php",
-        "opening_hours": "Mo 08:00 - 17:00; Tu 08:00 - 17:00; We 08:00 - 17:00; Th 08:00 - 17:00; Fr 08:00 - 17:00; Sa 10:00 - 18:00; Su 10:00 - 15:00; ",
+        "opening_hours": "Mo 08:00 - 17:00; Tu 08:00 - 17:00; We 08:00 - 17:00; Th 08:00 - 17:00; Fr 08:00 - 17:00; Sa 10:00 - 18:00; Su 10:00 - 15:00",
         "title": "Mobile Corona Tests BikeTaxi",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7565,7 +7565,7 @@
         "location": "Brandenburgische Str. 23 10707 Berlin",
         "telephone": null,
         "details_url": "https://app.testflow.eu/register/location/288593587750",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Mobiler Covid Testservice GBR",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -7587,7 +7587,7 @@
         "location": "Alt-Müggelheim 1 12559 Berlin",
         "telephone": null,
         "details_url": "https://mika-apotheken.de/",
-        "opening_hours": "Mo 08:00 - 18:30; Tu 08:00 - 18:30; We 08:00 - 18:30; Th 08:00 - 18:30; Fr 08:00 - 18:30; Sa 08:00 - 18:30; ",
+        "opening_hours": "Mo 08:00 - 18:30; Tu 08:00 - 18:30; We 08:00 - 18:30; Th 08:00 - 18:30; Fr 08:00 - 18:30; Sa 08:00 - 18:30",
         "title": "Müggel-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7609,7 +7609,7 @@
         "location": "Strasse zum Müggelturm 1 12559 Berlin",
         "telephone": null,
         "details_url": "http://www.müggelturm.berlin/",
-        "opening_hours": "Mo 06:00 - 22:00; Tu 06:00 - 22:00; We 06:00 - 22:00; Th 06:00 - 22:00; Fr 06:00 - 22:00; Sa 06:00 - 22:00; Su 06:00 - 22:00; ",
+        "opening_hours": "Mo 06:00 - 22:00; Tu 06:00 - 22:00; We 06:00 - 22:00; Th 06:00 - 22:00; Fr 06:00 - 22:00; Sa 06:00 - 22:00; Su 06:00 - 22:00",
         "title": "Müggelturm Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7631,7 +7631,7 @@
         "location": "Brunsbütteler Damm 263 13591 Berlin",
         "telephone": null,
         "details_url": "http://www.apotheke-mumm.de/",
-        "opening_hours": "Mo 12:00 - 14:00; We 12:00 - 14:00; Fr 12:00 - 14:00; ",
+        "opening_hours": "Mo 12:00 - 14:00; We 12:00 - 14:00; Fr 12:00 - 14:00",
         "title": "Mumm Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7653,7 +7653,7 @@
         "location": "Rosenthaler Str. 46/47 10178 Berlin",
         "telephone": null,
         "details_url": "https://www.praxisverbund-berlin.de/",
-        "opening_hours": "Mo 09:00 - 12:00,15:00 - 19:00; Tu 09:00 - 12:00,13:00 - 16:00; We 09:00 - 13:00; Th 09:00 - 12:00,15:00 - 19:00; Fr 09:00 - 13:00; ",
+        "opening_hours": "Mo 09:00 - 12:00,15:00 - 19:00; Tu 09:00 - 12:00,13:00 - 16:00; We 09:00 - 13:00; Th 09:00 - 12:00,15:00 - 19:00; Fr 09:00 - 13:00",
         "title": "MVZ Hackescher Markt",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -7675,7 +7675,7 @@
         "location": "Skalitzer Straße 33 10999 Berlin",
         "telephone": null,
         "details_url": "https://mvz-kreuzberg.de/informationen-zu-covid-19/ich-moechte-einen-covid-test-machen",
-        "opening_hours": "Mo 08:30 - 12:00; Tu 08:30 - 12:00; We 09:30 - 12:30; Th 08:30 - 12:00; Fr 09:30 - 12:30; ",
+        "opening_hours": "Mo 08:30 - 12:00; Tu 08:30 - 12:00; We 09:30 - 12:30; Th 08:30 - 12:00; Fr 09:30 - 12:30",
         "title": "MVZ Kreuzberg",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -7697,7 +7697,7 @@
         "location": "Brüsslerstraße 8/9 13353 Berlin",
         "telephone": null,
         "details_url": "https://www.myberlintest.de/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00",
         "title": "My Berlin Test",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -7719,7 +7719,7 @@
         "location": "Scharnweberstr. 65 13405 Berlin ",
         "telephone": "0152 21524866",
         "details_url": "http://www.nhp-vandreyhellwig.de/",
-        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30; ",
+        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30",
         "title": "Naturheilpraxis Kerstin Vandrey-Hellwig ",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7741,7 +7741,7 @@
         "location": "Scharnweberstr. 65 13405  Berlin",
         "telephone": "0152 21524866 ",
         "details_url": "http://www.nhp-vandreyhellwig.de/",
-        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30; ",
+        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30",
         "title": "Naturheilpraxis Kerstin Vandrey-Hellwig",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7763,7 +7763,7 @@
         "location": "Hönower Str. 16 12623 Berlin",
         "telephone": null,
         "details_url": "https://app.agendize.com/book/1016160933041581?lang=de",
-        "opening_hours": "Tu 18:00 - 20:00; Th 18:00 - 20:00; ",
+        "opening_hours": "Tu 18:00 - 20:00; Th 18:00 - 20:00",
         "title": "Neumann Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7785,7 +7785,7 @@
         "location": "Hanne-Sobek-Platz 13357 Berlin",
         "telephone": null,
         "details_url": "https://www.nordkreuz-apotheke.de/language/de/",
-        "opening_hours": "Mo 13:00 - 15:00; Tu 13:00 - 15:00; We 13:00 - 15:00; Th 13:00 - 15:00; Fr 13:00 - 15:00; ",
+        "opening_hours": "Mo 13:00 - 15:00; Tu 13:00 - 15:00; We 13:00 - 15:00; Th 13:00 - 15:00; Fr 13:00 - 15:00",
         "title": "Nordkreuz Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7807,7 +7807,7 @@
         "location": "Invalidenstr. 114 10115 Berlin",
         "telephone": null,
         "details_url": "http://www.nordlandapotheke-berlin.de/",
-        "opening_hours": "Mo 10:00 - 12:00,15:00 - 17:00; Tu 10:00 - 12:00,15:00 - 17:00; We 10:00 - 12:00,15:00 - 17:00; Th 10:00 - 12:00,15:00 - 17:00; Fr 10:00 - 12:00,15:00 - 17:00; ",
+        "opening_hours": "Mo 10:00 - 12:00,15:00 - 17:00; Tu 10:00 - 12:00,15:00 - 17:00; We 10:00 - 12:00,15:00 - 17:00; Th 10:00 - 12:00,15:00 - 17:00; Fr 10:00 - 12:00,15:00 - 17:00",
         "title": "Nordland Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7829,7 +7829,7 @@
         "location": "Grünauer Straße 7 12524 Berlin",
         "telephone": null,
         "details_url": "https://normannen-apotheke.de/schnelltest/",
-        "opening_hours": "Mo 08:20 - 12:40; Tu 08:20 - 12:40; We 08:20 - 12:40; Th 08:20 - 12:40; Fr 08:20 - 12:40; Sa 08:20 - 12:40; ",
+        "opening_hours": "Mo 08:20 - 12:40; Tu 08:20 - 12:40; We 08:20 - 12:40; Th 08:20 - 12:40; Fr 08:20 - 12:40; Sa 08:20 - 12:40",
         "title": "Normannen Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7851,7 +7851,7 @@
         "location": "Goerzallee 189-223 14167 Berlin",
         "telephone": null,
         "details_url": "http://www.testedichschnell.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 10:00 - 18:00",
         "title": "OBI Markt Berlin-Steglitz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7873,7 +7873,7 @@
         "location": "Waidmannsluster Damm 176 13469 Berlin",
         "telephone": null,
         "details_url": "https://www.ecocare.center/Apotheken/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00",
         "title": "Octopus Apotheke",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -7895,7 +7895,7 @@
         "location": "Panoramastr.1 10178 Berlin",
         "telephone": null,
         "details_url": "http://www.panoramaapotheke.de",
-        "opening_hours": "Mo 08:00 - 09:00,18:00 - 20:00; Tu 08:00 - 09:00,18:00 - 20:00; We 08:00 - 09:00,18:00 - 20:00; Th 08:00 - 09:00,18:00 - 20:00; Fr 08:00 - 09:00,18:00 - 20:00; Sa 14:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 09:00,18:00 - 20:00; Tu 08:00 - 09:00,18:00 - 20:00; We 08:00 - 09:00,18:00 - 20:00; Th 08:00 - 09:00,18:00 - 20:00; Fr 08:00 - 09:00,18:00 - 20:00; Sa 14:00 - 18:00",
         "title": "Panorama Apotheke am Alexanderplatz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7917,7 +7917,7 @@
         "location": "Sophienstraße 5 10178 Berlin",
         "telephone": null,
         "details_url": "https://www.panthermed.com/contact",
-        "opening_hours": "Mo 08:00 - 15:00; Tu 08:00 - 15:00; We 08:00 - 15:00; Th 08:00 - 15:00; Fr 08:00 - 15:00; ",
+        "opening_hours": "Mo 08:00 - 15:00; Tu 08:00 - 15:00; We 08:00 - 15:00; Th 08:00 - 15:00; Fr 08:00 - 15:00",
         "title": "Panthermed",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7939,7 +7939,7 @@
         "location": "Clayallee 175  14195  Berlin",
         "telephone": "030 84509600",
         "details_url": "https://www.bamdad.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 13:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 13:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 13:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 13:00",
         "title": "PB Coronatest to Go",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -7961,7 +7961,7 @@
         "location": "Bölschestraße 67 12587 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00",
         "title": "Peggy Meyer  - Haut & Haar",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -7983,7 +7983,7 @@
         "location": "Schivelbeinerstr. 42  10439  Berlin",
         "telephone": null,
         "details_url": "http://www.pensionmarie.de/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00",
         "title": "Pension Marie",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8005,7 +8005,7 @@
         "location": "Petersburger Platz 3 10249 Berlin",
         "telephone": null,
         "details_url": "https://testtermin.de/petersburger-apotheke-berlin/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 09:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 09:00 - 14:00",
         "title": "Petersburger Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8027,7 +8027,7 @@
         "location": "Metzer Str. 7  13595 Berlin",
         "telephone": null,
         "details_url": "https://www.pichelsdorfapotheke.de/",
-        "opening_hours": "Tu 13:00 - 17:00; We 13:00 - 17:00; Th 13:00 - 17:00; Fr 13:00 - 17:00; Sa 13:00 - 17:00; ",
+        "opening_hours": "Tu 13:00 - 17:00; We 13:00 - 17:00; Th 13:00 - 17:00; Fr 13:00 - 17:00; Sa 13:00 - 17:00",
         "title": "Pichelsdorf Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8049,7 +8049,7 @@
         "location": "Karl-Marx-Str. 88 12043 Berlin",
         "telephone": null,
         "details_url": "https://www.neukoelln-apotheke.de/",
-        "opening_hours": "Mo 08:30 - 20:00; Tu 08:30 - 20:00; We 08:30 - 20:00; Th 08:30 - 20:00; Fr 08:30 - 20:00; Sa 08:30 - 20:00; ",
+        "opening_hours": "Mo 08:30 - 20:00; Tu 08:30 - 20:00; We 08:30 - 20:00; Th 08:30 - 20:00; Fr 08:30 - 20:00; Sa 08:30 - 20:00",
         "title": "Pluspunkt Apotheke Neukölln",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8071,7 +8071,7 @@
         "location": "Linkstr. 4 10785 Berlin",
         "telephone": null,
         "details_url": "https://www.potsdamer-platz-apotheke.de/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00",
         "title": "Pluspunkt Apotheke Potsdamer Platz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8093,7 +8093,7 @@
         "location": "Fechnerstr.5 Berlin 10717",
         "telephone": "030 33875571",
         "details_url": "http://pn-pflege-netzwerk.de/",
-        "opening_hours": "Mo 10:00 - 16:30; Tu 10:00 - 16:30; We 10:00 - 16:30; Th 10:00 - 16:30; Fr 10:00 - 16:30; ",
+        "opening_hours": "Mo 10:00 - 16:30; Tu 10:00 - 16:30; We 10:00 - 16:30; Th 10:00 - 16:30; Fr 10:00 - 16:30",
         "title": "PN Pflege Netzwerk GmbH Test-To-Go",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8115,7 +8115,7 @@
         "location": "Sonnenallee 7  12045  Berlin",
         "telephone": null,
         "details_url": "http://www.poctestzentrum.de/",
-        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00; Su 10:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 19:00; Tu 07:00 - 19:00; We 07:00 - 19:00; Th 07:00 - 19:00; Fr 07:00 - 19:00; Sa 07:00 - 19:00; Su 10:00 - 20:00",
         "title": "POC Testzentrum",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -8137,7 +8137,7 @@
         "location": "Helene-Weigel-Platz 10 12681 Berlin",
         "telephone": null,
         "details_url": "https://www.poseidon-apotheke-app.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 18:00",
         "title": "Poseidon Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8159,7 +8159,7 @@
         "location": "Schmargendorfer Strasse 16 12159 Berlin",
         "telephone": null,
         "details_url": "https://www.praxis-bernhardt.com/termine/",
-        "opening_hours": "Mo 10:00 - 12:30; Tu 10:00 - 12:30; We 10:00 - 12:30; Th 10:00 - 12:30; Fr 10:00 - 12:30; ",
+        "opening_hours": "Mo 10:00 - 12:30; Tu 10:00 - 12:30; We 10:00 - 12:30; Th 10:00 - 12:30; Fr 10:00 - 12:30",
         "title": "Praxis Bernhardt",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -8181,7 +8181,7 @@
         "location": "Kyffhäuserstraße 11 10781 Berlin",
         "telephone": null,
         "details_url": "https://www.jameda.de/berlin/aerzte/innere-allgemeinmediziner/dr-nikolaus-peter-hoellen/uebersicht/80024409_1/",
-        "opening_hours": "Mo 08:00 - 11:00; Tu 08:00 - 11:00; We 08:00 - 11:00; Th 08:00 - 11:00; Fr 08:00 - 11:00; ",
+        "opening_hours": "Mo 08:00 - 11:00; Tu 08:00 - 11:00; We 08:00 - 11:00; Th 08:00 - 11:00; Fr 08:00 - 11:00",
         "title": "Praxis Dr. Höllen",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -8203,7 +8203,7 @@
         "location": "Godesberger Strasse 7 10318 Berlin",
         "telephone": null,
         "details_url": "https://praxis-korok.de/termin/",
-        "opening_hours": "Mo 08:00 - 14:00; Tu 08:00 - 14:00; We 08:00 - 14:00; Th 08:00 - 14:00; Fr 08:00 - 14:00; Sa 08:00 - 14:00; Su 08:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 14:00; Tu 08:00 - 14:00; We 08:00 - 14:00; Th 08:00 - 14:00; Fr 08:00 - 14:00; Sa 08:00 - 14:00; Su 08:00 - 14:00",
         "title": "Praxis Kai Korok",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8225,7 +8225,7 @@
         "location": "Schlüterstraße 38 10629 Berlin",
         "telephone": null,
         "details_url": "https://www.praxis-wuensche.com/",
-        "opening_hours": "Mo 08:00 - 12:30,14:00 - 17:00; Tu 08:00 - 12:03,14:00 - 17:00; We 08:00 - 12:30; Th 08:00 - 12:03,14:00 - 17:00; Fr 08:00 - 12:30; ",
+        "opening_hours": "Mo 08:00 - 12:30,14:00 - 17:00; Tu 08:00 - 12:03,14:00 - 17:00; We 08:00 - 12:30; Th 08:00 - 12:03,14:00 - 17:00; Fr 08:00 - 12:30",
         "title": "Praxis Wünsche",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8247,7 +8247,7 @@
         "location": "Schlossstrasse 11 14059 Berlin",
         "telephone": null,
         "details_url": "http://hausarztpraxis-zum-schloss.de/",
-        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; ",
+        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00",
         "title": "Praxis zum Schloss",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -8269,7 +8269,7 @@
         "location": "Kurfürstenstraße 57 12105 Berlin",
         "telephone": null,
         "details_url": "https://preussenapotheke.de/aktuelles/corona-schnelltests/corona-antigen/#termin",
-        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00; ",
+        "opening_hours": "Mo 08:30 - 19:00; Tu 08:30 - 19:00; We 08:30 - 19:00; Th 08:30 - 19:00; Fr 08:30 - 19:00",
         "title": "Preussen Apotheke Kurfürsten",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8291,7 +8291,7 @@
         "location": "Carl-Schurz-Str. 29 13597 Berlin",
         "telephone": null,
         "details_url": "https://preussenapotheke.de/aktuelles/corona-schnelltests/corona-antigen/#termin",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00",
         "title": "Preussen Apotheke Spandau",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -8313,7 +8313,7 @@
         "location": "Stülpnagelstraße 5 14059 Berlin",
         "telephone": null,
         "details_url": "https://quicktest.berlin/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Quicktest.Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -8335,7 +8335,7 @@
         "location": "Maybachufer 1  12047 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 10:00 - 18:00",
         "title": "RC Testzentrum Sonnenallee",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -8357,7 +8357,7 @@
         "location": "Leibnizstraße 58 10629 Berlin",
         "telephone": null,
         "details_url": "https://calendly.com/reonacoronacenterleibnizstr",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Reona Corona Test Center",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -8379,7 +8379,7 @@
         "location": "Nürnberger Str.19  10789  Berlin",
         "telephone": null,
         "details_url": "https://www.reona-corona-test.com/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00",
         "title": "Reona Corona Test Center Nürnberger",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -8401,7 +8401,7 @@
         "location": "Strausberger Platz 2 10243 Berlin",
         "telephone": null,
         "details_url": "http://www.amano-ristorante.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "Ristorante Amano",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8423,7 +8423,7 @@
         "location": "Siemensstr. 41 12247 Berlin",
         "telephone": null,
         "details_url": "https://app.no-q.info/roja-pharmazie/checkins#/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 10:00 - 15:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 10:00 - 15:00",
         "title": "Roja Pharmazie",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8445,7 +8445,7 @@
         "location": "Ostpreußendamm 3-17 12207 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 13:00 - 18:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 13:00 - 18:00; Fr 10:00 - 18:00; Sa 09:00 - 14:00; ",
+        "opening_hours": "Mo 13:00 - 18:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 13:00 - 18:00; Fr 10:00 - 18:00; Sa 09:00 - 14:00",
         "title": "Rotter Test-to-go Station",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8467,7 +8467,7 @@
         "location": "Ruschestr. 103 10365 Berlin",
         "telephone": null,
         "details_url": "https://app.no-q.info/rusche-apotheke/checkins#/",
-        "opening_hours": "Mo 08:30 - 18:30; Tu 08:30 - 18:30; We 08:30 - 18:30; Th 08:30 - 18:30; Fr 08:30 - 18:30; ",
+        "opening_hours": "Mo 08:30 - 18:30; Tu 08:30 - 18:30; We 08:30 - 18:30; Th 08:30 - 18:30; Fr 08:30 - 18:30",
         "title": "Rusche Apotheke",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -8511,7 +8511,7 @@
         "location": "Weinbergsweg 1 10119 Berlin",
         "telephone": null,
         "details_url": "https://www.sanimedius.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00",
         "title": "Sanimedius Apotheke am Rosenthaler Platz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8533,7 +8533,7 @@
         "location": "Mehrower Allee 22 12687 Berlin",
         "telephone": null,
         "details_url": "https://www.sanimedius.de/",
-        "opening_hours": "Mo 08:00 - 18:30; Tu 08:00 - 18:30; We 08:00 - 18:30; Th 08:00 - 18:30; Fr 08:00 - 18:30; ",
+        "opening_hours": "Mo 08:00 - 18:30; Tu 08:00 - 18:30; We 08:00 - 18:30; Th 08:00 - 18:30; Fr 08:00 - 18:30",
         "title": "Sanimedius Apotheke im Hufeland Ärztehaus",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8555,7 +8555,7 @@
         "location": "Pankower Allee 47/51 13409 Berlin",
         "telephone": null,
         "details_url": "https://www.sanimedius.de/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00",
         "title": "Sanimedius Apotheke Pankower Allee",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8577,7 +8577,7 @@
         "location": "Hauptstr. 151 10827 Berlin",
         "telephone": null,
         "details_url": "http://www.schaeffer-test-to-go.de/",
-        "opening_hours": "Mo 07:00 - 21:00; Tu 07:00 - 21:00; We 07:00 - 21:00; Th 07:00 - 21:00; Fr 07:00 - 21:00; Sa 07:00 - 21:00; Su 07:00 - 21:00; ",
+        "opening_hours": "Mo 07:00 - 21:00; Tu 07:00 - 21:00; We 07:00 - 21:00; Th 07:00 - 21:00; Fr 07:00 - 21:00; Sa 07:00 - 21:00; Su 07:00 - 21:00",
         "title": "SCHAEFFER COVID 19 Test-to-go",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8599,7 +8599,7 @@
         "location": "Schloßstraße 19 12163 Berlin",
         "telephone": null,
         "details_url": "http://www.schildhorn-apotheke-berlin.de/",
-        "opening_hours": "Mo 10:00 - 16:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 10:00 - 16:00; Fr 10:00 - 16:00; ",
+        "opening_hours": "Mo 10:00 - 16:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 10:00 - 16:00; Fr 10:00 - 16:00",
         "title": "Schildhorn Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8621,7 +8621,7 @@
         "location": "Streitstr. 8-9 13587  Berlin",
         "telephone": "0303351217",
         "details_url": "https://www.schluesseldienst-hakenfelde.de/",
-        "opening_hours": "Mo 10:00 - 15:00; Tu 10:00 - 15:00; We 10:00 - 15:00; Th 10:00 - 15:00; Fr 10:00 - 15:00; ",
+        "opening_hours": "Mo 10:00 - 15:00; Tu 10:00 - 15:00; We 10:00 - 15:00; Th 10:00 - 15:00; Fr 10:00 - 15:00",
         "title": "Schlüsseldienst Hakenfelde GbR",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8643,7 +8643,7 @@
         "location": "Hansastraße 236 13051 Berlin",
         "telephone": null,
         "details_url": "https://www.schneemannsapotheke.de/",
-        "opening_hours": "Mo 09:00 - 12:00,15:00 - 18:00; Tu 09:00 - 12:00,15:00 - 18:00; We 09:00 - 12:00,15:00 - 18:00; Th 09:00 - 12:00,15:00 - 18:00; Fr 09:00 - 12:00,15:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 12:00,15:00 - 18:00; Tu 09:00 - 12:00,15:00 - 18:00; We 09:00 - 12:00,15:00 - 18:00; Th 09:00 - 12:00,15:00 - 18:00; Fr 09:00 - 12:00,15:00 - 18:00",
         "title": "Schneemann`s Apotheke oHG",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8665,7 +8665,7 @@
         "location": "Fürstenwalder Allee 318 12589  Berlin",
         "telephone": null,
         "details_url": "https://www.schneemannsapotheke.de/",
-        "opening_hours": "We 09:00 - 12:00; Fr 09:00 - 12:00; ",
+        "opening_hours": "We 09:00 - 12:00; Fr 09:00 - 12:00",
         "title": "Schneemann`s Apotheke Rahnsdorf",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8687,7 +8687,7 @@
         "location": "Brunsbütteler Damm 321 13591 Berlin",
         "telephone": null,
         "details_url": "https://www.schnell-schneller-coronatest.de/bookings-checkout/schnelltest-b%C3%BCrgertest/book",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Schnell-schneller-Coronatest Brunsbütteler Damm",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8709,7 +8709,7 @@
         "location": "Schillerstr. 36 10627 Berlin",
         "telephone": null,
         "details_url": "https://www.schnell-schneller-coronatest.de/bookings-checkout/schnelltest-b%C3%BCrgertest/book",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Schnell-schneller-Coronatest Schillerstr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8731,7 +8731,7 @@
         "location": "Utrechter Str. 36 13347 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 09:00 - 16:00; ",
+        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 09:00 - 16:00",
         "title": "Schnell-Test-Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8753,7 +8753,7 @@
         "location": "Kurfürstendamm 71 10709 Berlin",
         "telephone": null,
         "details_url": "http://myderma.de/coronatest",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 17:00",
         "title": "Schnelltest Adenauerplatz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8775,7 +8775,7 @@
         "location": "Hermannstr. 59,  12049  Berlin",
         "telephone": null,
         "details_url": "http://schnelltestarena.de/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00",
         "title": "Schnelltest Arena Hermannstr. 59",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8797,7 +8797,7 @@
         "location": "Rheinstr. 20 12161  Berlin",
         "telephone": null,
         "details_url": "http://schnelltestarena.de/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00",
         "title": "Schnelltest Arena Rheinstr. 20",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8819,7 +8819,7 @@
         "location": "Scharnweberstr. 138 12459  Berlin",
         "telephone": null,
         "details_url": "http://schnelltestarena.de/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00",
         "title": "Schnelltest Arena Scharnweberstr. 138",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8841,7 +8841,7 @@
         "location": "Wohlrabedamm 34 13629 Berlin",
         "telephone": null,
         "details_url": "https://schnelltest-deutschland.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "Schnelltest Deutschland Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8863,7 +8863,7 @@
         "location": "Friedrichstraße 116 10117  Berlin",
         "telephone": null,
         "details_url": "https://www.myderma.de/corona-test/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 10:00 - 16:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; Su 10:00 - 16:00",
         "title": "Schnelltest Friedrichstraße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8885,7 +8885,7 @@
         "location": "Falckensteinstraße 38 10997 Berlin",
         "telephone": null,
         "details_url": "http://www.schnelltest-kreuzberg.de/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00",
         "title": "Schnelltest Kreuzberg",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -8907,7 +8907,7 @@
         "location": "Nordlichtstraße 3 13405 Berlin",
         "telephone": null,
         "details_url": "https://schnelltest-kutschi.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 16:00",
         "title": "Schnelltest Kutschi",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8929,7 +8929,7 @@
         "location": "Alt-Tegel 5 13507 Berlin",
         "telephone": null,
         "details_url": "https://schnelltest-tegel.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 16:00",
         "title": "Schnelltest Tegel",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8951,7 +8951,7 @@
         "location": "Am Juliusturm 44 13599 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00",
         "title": "schnelltest15 Center Am Juliusturm",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8973,7 +8973,7 @@
         "location": "Charlottenstr. 24 13597 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 11:00 - 17:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 11:00 - 17:00",
         "title": "schnelltest15 Charlottenstraße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -8995,7 +8995,7 @@
         "location": "Friedrich-Wilhelm-Platz 16 12161 Berlin",
         "telephone": null,
         "details_url": "https://www.schnelltest15.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "schnelltest15 Friedrich-Wilhelm-Platz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9017,7 +9017,7 @@
         "location": "Landhausstr. 31 10717 Berlin",
         "telephone": null,
         "details_url": "https://www.schnelltest15.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "schnelltest15 Landhausstr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9039,7 +9039,7 @@
         "location": "Hermsdorfer Damm 195 13467  Berlin",
         "telephone": null,
         "details_url": "https://www.schnelltest15.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 11:00 - 17:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 11:00 - 17:00",
         "title": "schnelltest15 Maria Gnaden",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9061,7 +9061,7 @@
         "location": "Naugarder Str. 8 10409 Berlin",
         "telephone": null,
         "details_url": "https://www.schnelltest15.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "schnelltest15 Naugarder Str.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9083,7 +9083,7 @@
         "location": "Wilhemsruher Damm 144,  13439  Berlin",
         "telephone": null,
         "details_url": "https://www.schnelltest15.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 11:00 - 17:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 11:00 - 17:00",
         "title": "schnelltest15 St. Martin Märkisches Viertel",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9105,7 +9105,7 @@
         "location": "Greifswalder Str. 33 10405 Berlin",
         "telephone": null,
         "details_url": "http://www.schnelltest2go.de",
-        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; Su 10:00 - 19:00; ",
+        "opening_hours": "Mo 10:00 - 19:00; Tu 10:00 - 19:00; We 10:00 - 19:00; Th 10:00 - 19:00; Fr 10:00 - 19:00; Sa 10:00 - 19:00; Su 10:00 - 19:00",
         "title": "Schnelltest2go",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9127,7 +9127,7 @@
         "location": "Eberswalder Str. 41 10437 Berlin",
         "telephone": null,
         "details_url": "https://schnelltestberlin.de/prenzlauer-berg",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "SchnelltestBerlin.de | Mauerpark",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -9149,7 +9149,7 @@
         "location": "Rhinstraße 17 10315 Berlin",
         "telephone": null,
         "details_url": "https://www.bk-apo.de/die-apotheken/apotheke-an-der-rhinstrasse/schnellteststation/",
-        "opening_hours": "Mo 09:00 - 22:00; Tu 09:00 - 22:00; We 09:00 - 22:00; Th 09:00 - 22:00; Fr 09:00 - 22:00; Sa 09:00 - 22:00; Su 09:00 - 22:00; ",
+        "opening_hours": "Mo 09:00 - 22:00; Tu 09:00 - 22:00; We 09:00 - 22:00; Th 09:00 - 22:00; Fr 09:00 - 22:00; Sa 09:00 - 22:00; Su 09:00 - 22:00",
         "title": "Schnellteststation Apotheke Rhinstraße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9171,7 +9171,7 @@
         "location": "Schnellerstr. 137 12439  Berlin",
         "telephone": null,
         "details_url": "https://schnelltest-baerenquell.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 09:00 - 14:00; Su 09:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 09:00 - 14:00; Su 09:00 - 14:00",
         "title": "Schnelltestzentrum Baerenquell",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9193,7 +9193,7 @@
         "location": "Görlitzerstr. 71 10997  Berlin",
         "telephone": null,
         "details_url": "https://gqs.jimdosite.com",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00",
         "title": "Schnelltestzentrum Berlin Kreuzberg Görlitzerstr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9215,7 +9215,7 @@
         "location": "Wöhlertstr. 4 10115 Berlin",
         "telephone": null,
         "details_url": "http://www.covid-schnelltestung.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Schnelltestzentrum Berlin-Mitte",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9237,7 +9237,7 @@
         "location": "Buschkrugallee 131 12359 Berlin",
         "telephone": null,
         "details_url": "www.negativer-schnelltest.de",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00",
         "title": "Schnelltestzentrum im Diakonie-Haus Britz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9259,7 +9259,7 @@
         "location": "Fechnerstr. 5 10717 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 15:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 15:00",
         "title": "Sealdex Test2Go Stelle",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9281,7 +9281,7 @@
         "location": "Blücher Str.9     10961  Berlin",
         "telephone": null,
         "details_url": "https://covidtest-sofort.de/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00",
         "title": "Simit Sarayi",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -9303,7 +9303,7 @@
         "location": "Passauer Strasse 33 10789  Berlin",
         "telephone": "0177 5026289",
         "details_url": "https://www.skin-ipl2.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "Skin-IPL2",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9325,7 +9325,7 @@
         "location": "Nöldnerstr.1 10317  Berlin",
         "telephone": null,
         "details_url": "https://app.clickandtest.de/#/pages/welcome",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00",
         "title": "Smart Corona Schnelltest",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9347,7 +9347,7 @@
         "location": "Riesaer Str. 102 12627 Berlin",
         "telephone": null,
         "details_url": "https://schnelltest.apomondo.online/#/termine/68e9bc38-b7ca-4615-a45c-4cec2483c5d9",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 10:00 - 12:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 10:00 - 12:00",
         "title": "Sonnenhut Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9369,7 +9369,7 @@
         "location": "Treskowallee 128 10318 Berlin",
         "telephone": null,
         "details_url": "https://sonnenschein-apotheke.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 13:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 13:00",
         "title": "Sonnenschein-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9391,7 +9391,7 @@
         "location": "Grünberger Str. 26 10245 Berlin",
         "telephone": null,
         "details_url": "https://sozialmaske.de/testen",
-        "opening_hours": "Mo 11:00 - 18:00; Tu 11:00 - 18:00; We 11:00 - 18:00; Th 11:00 - 18:00; Fr 11:00 - 18:00; Sa 11:00 - 18:00; Su 11:00 - 18:00; ",
+        "opening_hours": "Mo 11:00 - 18:00; Tu 11:00 - 18:00; We 11:00 - 18:00; Th 11:00 - 18:00; Fr 11:00 - 18:00; Sa 11:00 - 18:00; Su 11:00 - 18:00",
         "title": "Sozialmaske.de Testzentrum G26",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9413,7 +9413,7 @@
         "location": "Wilhelmsaue 132 10715 Berlin",
         "telephone": null,
         "details_url": "http://www.corona-test-wilmersdorf.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 16:00; Su 10:00 - 15:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 16:00; Su 10:00 - 15:00",
         "title": "Sozialmedizinisches Gutachteninstitut Berlin",
         "hints": [
           "PCR-Nachtestung: mit",
@@ -9435,7 +9435,7 @@
         "location": "Lichtenrader Damm 160 12305  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 07:30 - 16:00; Tu 07:30 - 16:00; We 07:30 - 16:00; Th 07:30 - 16:00; Fr 07:30 - 16:00; Sa 07:30 - 16:00; Su 07:30 - 16:00; ",
+        "opening_hours": "Mo 07:30 - 16:00; Tu 07:30 - 16:00; We 07:30 - 16:00; Th 07:30 - 16:00; Fr 07:30 - 16:00; Sa 07:30 - 16:00; Su 07:30 - 16:00",
         "title": "Sporteve Testzentrum Lichtenrade",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9457,7 +9457,7 @@
         "location": "Alt-Moabit 89 10559  Berlin",
         "telephone": null,
         "details_url": "https://www.apomondo.de/",
-        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; ",
+        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00",
         "title": "Spree Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9479,7 +9479,7 @@
         "location": "Palisadenstraße 72 10243 Berlin",
         "telephone": null,
         "details_url": "https://estaruppin.de/",
-        "opening_hours": "Mo 19:00 - 21:30; Tu 19:00 - 21:30; We 19:00 - 21:30; Th 19:00 - 21:30; Fr 19:00 - 21:30; ",
+        "opening_hours": "Mo 19:00 - 21:30; Tu 19:00 - 21:30; We 19:00 - 21:30; Th 19:00 - 21:30; Fr 19:00 - 21:30",
         "title": "St. Pius",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9501,7 +9501,7 @@
         "location": "Georgenstr. 196 10117 Berlin",
         "telephone": null,
         "details_url": "https://schnelltestzentrum-aerticket.de/berlin-georgen-str/",
-        "opening_hours": "Mo 08:30 - 16:30; Tu 08:30 - 16:30; We 08:30 - 16:30; Th 08:30 - 16:30; Fr 08:30 - 16:30; ",
+        "opening_hours": "Mo 08:30 - 16:30; Tu 08:30 - 16:30; We 08:30 - 16:30; Th 08:30 - 16:30; Fr 08:30 - 16:30",
         "title": "STA Travel AERTICKET",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9523,7 +9523,7 @@
         "location": "Teltower Damm 5 14169 Berlin-Zehlendorf",
         "telephone": null,
         "details_url": "http://www.stadtapotheke-berlin.de",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00",
         "title": "Stadt-Apotheke",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -9545,7 +9545,7 @@
         "location": "Grünstr.24 12555 Berlin",
         "telephone": null,
         "details_url": "https://www.stadt-apotheke-koepenick.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 13:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 09:00 - 13:00",
         "title": "Stadt-Apotheke Köpenick",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9567,7 +9567,7 @@
         "location": "Fachinger Str. 16 13591 Berlin",
         "telephone": null,
         "details_url": "https://covisa.de/covisacenter",
-        "opening_hours": "Mo 10:00 - 15:00; Tu 10:00 - 15:00; We 10:00 - 15:00; Th 10:00 - 15:00; Fr 10:00 - 15:00; ",
+        "opening_hours": "Mo 10:00 - 15:00; Tu 10:00 - 15:00; We 10:00 - 15:00; Th 10:00 - 15:00; Fr 10:00 - 15:00",
         "title": "Stadt-Apotheke Staaken",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9589,7 +9589,7 @@
         "location": "Kirchstr. 1, (Ecke Teltower Damm)  14163  Berlin",
         "telephone": null,
         "details_url": "https://www.stadtapotheke-berlin.de/",
-        "opening_hours": "Mo 09:30 - 16:00; Tu 09:30 - 16:00; We 09:30 - 16:00; Th 09:30 - 16:00; Fr 09:30 - 16:00; Sa 09:30 - 16:00; ",
+        "opening_hours": "Mo 09:30 - 16:00; Tu 09:30 - 16:00; We 09:30 - 16:00; Th 09:30 - 16:00; Fr 09:30 - 16:00; Sa 09:30 - 16:00",
         "title": "Stadt-Apotheke, Testzelt Rathausplatz",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -9611,7 +9611,7 @@
         "location": "Klarastr. 6 12459 Berlin",
         "telephone": null,
         "details_url": "https://www.schnell-testberlin.de/",
-        "opening_hours": "Mo 08:00 - 16:00; Tu 08:00 - 16:00; We 08:00 - 16:00; Th 08:00 - 16:00; Fr 08:00 - 16:00; Sa 09:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 16:00; Tu 08:00 - 16:00; We 08:00 - 16:00; Th 08:00 - 16:00; Fr 08:00 - 16:00; Sa 09:00 - 16:00",
         "title": "STB Schnell- Test - Berlin Klarastr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9633,7 +9633,7 @@
         "location": "Nürnberger Str. 68 10787  Berlin",
         "telephone": null,
         "details_url": "https://www.schnell-testberlin.de/",
-        "opening_hours": "Mo 07:00 - 16:00; Tu 07:00 - 16:00; We 07:00 - 16:00; Th 07:00 - 16:00; Fr 07:00 - 16:00; Sa 08:00 - 16:00; ",
+        "opening_hours": "Mo 07:00 - 16:00; Tu 07:00 - 16:00; We 07:00 - 16:00; Th 07:00 - 16:00; Fr 07:00 - 16:00; Sa 08:00 - 16:00",
         "title": "STB Schnell- Test - Berlin Nürnberger Str.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9655,7 +9655,7 @@
         "location": "Heidenfeldstr. 11 10249 Berlin",
         "telephone": null,
         "details_url": "https://www.schnell-testberlin.de/termin",
-        "opening_hours": "Mo 08:00 - 16:00; Tu 08:00 - 16:00; We 08:00 - 16:00; Th 08:00 - 16:00; Fr 08:00 - 16:00; Sa 09:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 16:00; Tu 08:00 - 16:00; We 08:00 - 16:00; Th 08:00 - 16:00; Fr 08:00 - 16:00; Sa 09:00 - 16:00",
         "title": "STB Schnell-Test-Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9677,7 +9677,7 @@
         "location": "Müllerstrasse 96 13349 Berlin",
         "telephone": null,
         "details_url": "https://steinbockapotheke.de/",
-        "opening_hours": "Mo 09:00 - 18:30; Tu 09:00 - 18:30; We 09:00 - 18:30; Th 09:00 - 18:30; Fr 09:00 - 18:30; Sa 09:00 - 13:00; ",
+        "opening_hours": "Mo 09:00 - 18:30; Tu 09:00 - 18:30; We 09:00 - 18:30; Th 09:00 - 18:30; Fr 09:00 - 18:30; Sa 09:00 - 13:00",
         "title": "Steinbock Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9699,7 +9699,7 @@
         "location": "Pistoriusstraße 6 13086 Berlin",
         "telephone": null,
         "details_url": "https://stephanus.easy2book.de/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00",
         "title": "Stephanus Stiftung",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9721,7 +9721,7 @@
         "location": "Kantstr.107,  10627  Berlin",
         "telephone": null,
         "details_url": "https://www.stern-apotheke-berlin.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 15:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 15:00",
         "title": "Stern Apotheke",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -9743,7 +9743,7 @@
         "location": "Baumschulenstr. 96 12437 Berlin",
         "telephone": "030 53027866",
         "details_url": "https://www.sternapotheke-berlin.de/website/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00",
         "title": "Stern-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9765,7 +9765,7 @@
         "location": "Berliner Allee 155 13088 Berlin",
         "telephone": null,
         "details_url": "http://www.schnelltest-berlin.com/termin-buchen/",
-        "opening_hours": "Mo 14:00 - 17:00; Tu 14:00 - 17:00; We 14:00 - 17:00; Th 14:00 - 17:00; Fr 14:00 - 17:00; Sa 10:00 - 13:00; Su 10:00 - 13:00; ",
+        "opening_hours": "Mo 14:00 - 17:00; Tu 14:00 - 17:00; We 14:00 - 17:00; Th 14:00 - 17:00; Fr 14:00 - 17:00; Sa 10:00 - 13:00; Su 10:00 - 13:00",
         "title": "STZ Weissensee",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -9787,7 +9787,7 @@
         "location": "Wilhelmsruher Damm 129 13439  Berlin",
         "telephone": null,
         "details_url": "https://stz-berlin.de/TERMINE/index.php/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00",
         "title": "STZ-Berlin Wilhelmsruher Damm",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -9809,7 +9809,7 @@
         "location": "Suarezstraße 64 14057 Berlin",
         "telephone": null,
         "details_url": "http://www.suarez-apotheke.de/",
-        "opening_hours": "Mo 10:00 - 16:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 10:00 - 16:00; Fr 10:00 - 16:00; Sa 10:00 - 16:00; ",
+        "opening_hours": "Mo 10:00 - 16:00; Tu 10:00 - 16:00; We 10:00 - 16:00; Th 10:00 - 16:00; Fr 10:00 - 16:00; Sa 10:00 - 16:00",
         "title": "Suarez Apotheke Teststelle",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9831,7 +9831,7 @@
         "location": "Birkbuschstr. 59 12167 Berlin",
         "telephone": null,
         "details_url": "https://www.tannenbergapotheke.de/terminkalender/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00",
         "title": "Tannenberg Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9853,7 +9853,7 @@
         "location": "Liebenwalder Straße 38 13347  Berlin",
         "telephone": null,
         "details_url": "https://www.tarons-teststationen.de/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00",
         "title": "Tarons Teststation Liebenwalder Straße",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -9875,7 +9875,7 @@
         "location": "Detmolder Straße 67 10715  Berlin",
         "telephone": null,
         "details_url": "https://www.tarons-teststationen.de/",
-        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 09:00 - 16:00; Su 09:00 - 16:00; ",
+        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 09:00 - 16:00; Su 09:00 - 16:00",
         "title": "Tarons Teststation Wilmersdorf",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -9897,7 +9897,7 @@
         "location": "Straße des 17. Juni 135 10623 Berlin",
         "telephone": null,
         "details_url": "https://www.covid-testzentrum.de/tuberlin",
-        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; ",
+        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00",
         "title": "Technische Universität Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -9919,7 +9919,7 @@
         "location": "Schillerpromenade 11  12049 Berlin",
         "telephone": null,
         "details_url": "https://testzentrum-berlin-brandenburg.de/terminbuchung/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "Tesetzentrum Berlin Neukölln",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -9941,7 +9941,7 @@
         "location": "Ollenhauerstr.35    13403 Berlin",
         "telephone": "0157 81392347",
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:30 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:30 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 18:00",
         "title": "Test 24/7",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -9963,7 +9963,7 @@
         "location": "Berliner Str. 79 13189  Berlin",
         "telephone": null,
         "details_url": "https://www.test-to-go.studio/termin",
-        "opening_hours": "Mo 08:00 - 12:00; Tu 08:00 - 12:00; We 08:00 - 12:00; Th 08:00 - 12:00; Fr 08:00 - 12:00; Sa 08:00 - 12:00; Su 08:00 - 12:00; ",
+        "opening_hours": "Mo 08:00 - 12:00; Tu 08:00 - 12:00; We 08:00 - 12:00; Th 08:00 - 12:00; Fr 08:00 - 12:00; Sa 08:00 - 12:00; Su 08:00 - 12:00",
         "title": "Test Station Berliner79",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10007,7 +10007,7 @@
         "location": "Ahrensfelder Chaussee 142 A 12689 Berlin",
         "telephone": "030 84711100",
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Test Zentrum Ahrensfelde",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10029,7 +10029,7 @@
         "location": "Residenzstr. 42 13409 Berlin",
         "telephone": "0157 81391961",
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Test-Home",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10051,7 +10051,7 @@
         "location": "Osdorfer Str. 125 12207  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Test-To-Go-Station Osdorfer Straße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10073,7 +10073,7 @@
         "location": "Greifenhagener Str. 64 10437  Berlin",
         "telephone": null,
         "details_url": "https://calendly.com/test-zentrum-academy",
-        "opening_hours": "Mo 09:30 - 15:00; Tu 09:30 - 15:00; We 09:30 - 15:00; Th 09:30 - 15:00; Fr 09:30 - 15:00; Sa 10:00 - 12:00; Su 10:00 - 12:00; ",
+        "opening_hours": "Mo 09:30 - 15:00; Tu 09:30 - 15:00; We 09:30 - 15:00; Th 09:30 - 15:00; Fr 09:30 - 15:00; Sa 10:00 - 12:00; Su 10:00 - 12:00",
         "title": "Test-Zentrum-Prenzlauerberg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10095,7 +10095,7 @@
         "location": "Reuterstr. 78 12053  Berlin",
         "telephone": null,
         "details_url": "https://www.facebook.com/Test2Go.Hamdt",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "Test2Go-Hamdt",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10117,7 +10117,7 @@
         "location": "Potsdammerstraße 172 10783  Berlin",
         "telephone": null,
         "details_url": "https://www.facebook.com/Test2Go-Wannini-100880288828237",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "Test2Go-Wannini",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10139,7 +10139,7 @@
         "location": "Invalidenstraße 3 10115 Berlin",
         "telephone": null,
         "details_url": "http://www.test4culture.elisabeth.berlin/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "Test4Culture - Testzentrum in der Villa Elisabeth",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10161,7 +10161,7 @@
         "location": "Gutschmidtstr. 27-29  12359  Berlin",
         "telephone": null,
         "details_url": "http://cs-medical-services.de/",
-        "opening_hours": "Mo 08:00 - 17:00; Tu 08:00 - 17:00; We 08:00 - 17:00; Th 08:00 - 17:00; Fr 08:00 - 17:00; Sa 08:00 - 17:00; ",
+        "opening_hours": "Mo 08:00 - 17:00; Tu 08:00 - 17:00; We 08:00 - 17:00; Th 08:00 - 17:00; Fr 08:00 - 17:00; Sa 08:00 - 17:00",
         "title": "testbar Britz süd",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10183,7 +10183,7 @@
         "location": "Berliner Str. 30 10715 Berlin",
         "telephone": null,
         "details_url": "http://www.testcenterberlin.de/",
-        "opening_hours": "Mo 08:00 - 16:00; Tu 08:00 - 16:00; We 08:00 - 16:00; Th 08:00 - 16:00; Fr 08:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 16:00; Tu 08:00 - 16:00; We 08:00 - 16:00; Th 08:00 - 16:00; Fr 08:00 - 16:00",
         "title": "Testcenter Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10205,7 +10205,7 @@
         "location": "Wartenberg Str. 174 13051  Berlin",
         "telephone": null,
         "details_url": "https://berlin11.testcenter-corona.de",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00",
         "title": "Testcenter Corona",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10227,7 +10227,7 @@
         "location": "Boxhagener Str. 26  10245  Berlin",
         "telephone": null,
         "details_url": "https://berlin10.testcenter-corona.de",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00",
         "title": "Testcenter Corona Boxhagener Str. ",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10249,7 +10249,7 @@
         "location": "Hedwig-Wachenheim-Str. 14 10243 Berlin",
         "telephone": null,
         "details_url": "https://berlin3.testcenter-corona.de/",
-        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; Su 10:00 - 20:00; ",
+        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; Su 10:00 - 20:00",
         "title": "Testcenter Corona Hedwig-Wachenheim-Str.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10271,7 +10271,7 @@
         "location": "Bismarckallee 23  14193  Berlin",
         "telephone": null,
         "details_url": "https://berlin12.testcenter-corona.de/",
-        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 09:00 - 16:00; Su 09:00 - 16:00; ",
+        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 09:00 - 16:00; Su 09:00 - 16:00",
         "title": "Testcenter Corona Johannisches Sozialwerk e.V.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10293,7 +10293,7 @@
         "location": "Memhardstr. 1 10178 Berlin",
         "telephone": null,
         "details_url": "https://berlin4.testcenter-corona.de/",
-        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; Su 10:00 - 20:00; ",
+        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; Su 10:00 - 20:00",
         "title": "Testcenter Corona Memharstr.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10315,7 +10315,7 @@
         "location": "Park Center am Bahnhof Rathaus Steglitz (S+U) (Ausgang Kuhligkshofstr.) Kuhligkshofstraße 3   12165 Berlin",
         "telephone": null,
         "details_url": "https://berlin8.testcenter-corona.de",
-        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 10:00 - 15:00; ",
+        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 10:00 - 15:00",
         "title": "Testcenter Corona Park Center ",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10337,7 +10337,7 @@
         "location": "Potsdamer Str. 2 10785 Berlin",
         "telephone": null,
         "details_url": "https://berlin5.testcenter-corona.de/",
-        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; Su 10:00 - 20:00; ",
+        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; Su 10:00 - 20:00",
         "title": "Testcenter Corona Potsdamer Str.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10359,7 +10359,7 @@
         "location": "Residenzstr. 43  13409  Berlin",
         "telephone": null,
         "details_url": "https://berlin7.testcenter-corona.de",
-        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 10:00 - 15:00; ",
+        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 10:00 - 15:00",
         "title": "Testcenter Corona Residenzstr.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10381,7 +10381,7 @@
         "location": "Veteranenstraße 26  10119  Berlin",
         "telephone": null,
         "details_url": "https://berlin9.testcenter-corona.de",
-        "opening_hours": "Mo 08:00 - 16:00; Tu 08:00 - 16:00; We 08:00 - 16:00; Th 08:00 - 16:00; Fr 08:00 - 16:00; Sa 10:00 - 16:00; Su 10:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 16:00; Tu 08:00 - 16:00; We 08:00 - 16:00; Th 08:00 - 16:00; Fr 08:00 - 16:00; Sa 10:00 - 16:00; Su 10:00 - 16:00",
         "title": "Testcenter Corona Veteranenstraße",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10403,7 +10403,7 @@
         "location": "Zeltinger Straße 6 13465 Berlin",
         "telephone": null,
         "details_url": "https://schnelltest.apomondo.online/#/termine/94b7b93b-f924-4ce0-9219-ddc1bfdd534c",
-        "opening_hours": "Mo 09:00 - 13:00; Tu 09:00 - 13:00; We 09:00 - 13:00; Th 09:00 - 13:00; Fr 09:00 - 13:00; ",
+        "opening_hours": "Mo 09:00 - 13:00; Tu 09:00 - 13:00; We 09:00 - 13:00; Th 09:00 - 13:00; Fr 09:00 - 13:00",
         "title": "Testcenter Frohnau im Centre Bagatelle",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10425,7 +10425,7 @@
         "location": "Nollendorfplatz 5 10777 Berlin",
         "telephone": null,
         "details_url": "https://testcenter-nollendorfplatz.de/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "Testcenter Nollerdorfplatz",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10447,7 +10447,7 @@
         "location": "Roedernallee 17 13407 Berlin",
         "telephone": null,
         "details_url": "https://testcenter-roedernallee.de/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 09:00 - 19:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 09:00 - 19:00",
         "title": "Testcenter Roedernallee",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10469,7 +10469,7 @@
         "location": "Tempelhoferdamm 154 12099  Berlin",
         "telephone": null,
         "details_url": "https://testcenter-tempelhoferdamm.de/anmeldung-corona-testcenter-tempelhofer-damm ",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 09:00 - 18:00",
         "title": "Testcenter Tempelhofer Damm",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10491,7 +10491,7 @@
         "location": "Schiffbauerdamm 12 10117  Berlin",
         "telephone": null,
         "details_url": "https://teste-dich-berlin.de/#termin-reservierung",
-        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30; Su 09:30 - 18:30; ",
+        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30; Su 09:30 - 18:30",
         "title": "Teste Dich Berlin",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10513,7 +10513,7 @@
         "location": "Bizetstr. 41 13088 Berlin",
         "telephone": null,
         "details_url": "https://www.esi-shiatsu.de/kontakt/hier-termin-buchen-fuer-kostenfreie-antigentests.html",
-        "opening_hours": "Mo 08:30 - 09:30; Fr 16:00 - 17:00; Sa 08:30 - 09:30; ",
+        "opening_hours": "Mo 08:30 - 09:30; Fr 16:00 - 17:00; Sa 08:30 - 09:30",
         "title": "Testen am ESI",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10535,7 +10535,7 @@
         "location": "Nansenstr. 22 12047  Berlin",
         "telephone": null,
         "details_url": "https://www.testgiganten.de/",
-        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 06:00 - 20:00; ",
+        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 06:00 - 20:00",
         "title": "Testgiganten Neukölln",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10557,7 +10557,7 @@
         "location": "Schönwalder Str. 24 13347  Berlin",
         "telephone": null,
         "details_url": "http://testino.work/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Testino Schönwalder Str.24",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10579,7 +10579,7 @@
         "location": "Kolkrabenweg 40 12351  Berlin",
         "telephone": "030 98389867",
         "details_url": "https://www.testit24.de/",
-        "opening_hours": "Mo 09:00 - 19:30; Tu 09:00 - 19:30; We 09:00 - 19:30; Th 09:00 - 19:30; Fr 09:00 - 19:30; Sa 09:00 - 19:30; ",
+        "opening_hours": "Mo 09:00 - 19:30; Tu 09:00 - 19:30; We 09:00 - 19:30; Th 09:00 - 19:30; Fr 09:00 - 19:30; Sa 09:00 - 19:30",
         "title": "Testit24",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10601,7 +10601,7 @@
         "location": "Hermsdorferdamm 96  13467  Berlin",
         "telephone": "0173 1030304",
         "details_url": "",
-        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; Sa 07:00 - 18:00; Su 07:00 - 18:00; ",
+        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; Sa 07:00 - 18:00; Su 07:00 - 18:00",
         "title": "Teststation - Nord",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10623,7 +10623,7 @@
         "location": "Herrmannstr. 158  12051  Berlin",
         "telephone": null,
         "details_url": "https://covidtest-sofort.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Teststation am Hermann Quartier",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10645,7 +10645,7 @@
         "location": "Auguste Viktoria Allee 3 13409 Berlin",
         "telephone": null,
         "details_url": "https://www.corona-teststation-reinickendorf.de/",
-        "opening_hours": "Mo 07:00 - 17:00; Tu 07:00 - 17:00; We 07:00 - 17:00; Th 07:00 - 17:00; Fr 07:00 - 17:00; Sa 09:00 - 15:00; ",
+        "opening_hours": "Mo 07:00 - 17:00; Tu 07:00 - 17:00; We 07:00 - 17:00; Th 07:00 - 17:00; Fr 07:00 - 17:00; Sa 09:00 - 15:00",
         "title": "Teststation Auguste Viktoria Allee",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10667,7 +10667,7 @@
         "location": "Malchower Chaussee 10, Parkplatz Baumarkt - Hornbach 13088  Berlin",
         "telephone": null,
         "details_url": "https://jokerbowl.covidservicepoint.de/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 08:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 08:00 - 20:00",
         "title": "Teststation Berlin-Weißensee bei Hornbach",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10689,7 +10689,7 @@
         "location": "Fürstenwalder Damm 479 12587 Berlin",
         "telephone": null,
         "details_url": "http://www.pandemedics.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Teststation Friedrichshagen",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10711,7 +10711,7 @@
         "location": "Blücher Str. 9 10961 Berlin",
         "telephone": null,
         "details_url": "https://covidtest-sofort.de/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00",
         "title": "Teststation H & V Möbel",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10733,7 +10733,7 @@
         "location": "Niderbarnimstr.  13   10247  Berlin",
         "telephone": null,
         "details_url": "https://covidtest-sofort.de/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00",
         "title": "Teststation Papa Pane",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10755,7 +10755,7 @@
         "location": "Grossbeerenstrasse 64 10963  Berlin",
         "telephone": null,
         "details_url": "http://www.schiwagofilm.de/teststation",
-        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30; Su 09:30 - 18:30; ",
+        "opening_hours": "Mo 09:30 - 18:30; Tu 09:30 - 18:30; We 09:30 - 18:30; Th 09:30 - 18:30; Fr 09:30 - 18:30; Sa 09:30 - 18:30; Su 09:30 - 18:30",
         "title": "Teststation Schiwago Film",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10777,7 +10777,7 @@
         "location": "Klosterstr. 38 13581 Berlin",
         "telephone": null,
         "details_url": "https://www.teststation-spandau.de",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 08:00 - 20:00; Su 10:00 - 18:00",
         "title": "Teststation Spandau / Altes Postgelände",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10799,7 +10799,7 @@
         "location": "Rheinstr. 60 12159  Berlin",
         "telephone": null,
         "details_url": "https://covidtest-sofort.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Teststation Statement",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10821,7 +10821,7 @@
         "location": "Wilmersdorfer Str. 45  10627  Berlin",
         "telephone": null,
         "details_url": "https://covidtest-sofort.de/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00",
         "title": "Teststation Sunpoint",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10843,7 +10843,7 @@
         "location": "Skalitzer Strasse 137   10999 Berlin",
         "telephone": null,
         "details_url": "https://covidtest-sofort.de/",
-        "opening_hours": "Mo 08:00 - 17:00; Tu 08:00 - 17:00; We 08:00 - 17:00; Th 08:00 - 17:00; Fr 08:00 - 17:00; Sa 08:00 - 17:00; Su 08:00 - 17:00; ",
+        "opening_hours": "Mo 08:00 - 17:00; Tu 08:00 - 17:00; We 08:00 - 17:00; Th 08:00 - 17:00; Fr 08:00 - 17:00; Sa 08:00 - 17:00; Su 08:00 - 17:00",
         "title": "Teststation United Dentists",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10865,7 +10865,7 @@
         "location": "Prinzenallee 86b 13357  Berlin",
         "telephone": null,
         "details_url": "http://coronatestzentrum-berlin.de/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00",
         "title": "Teststation Wedding",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10887,7 +10887,7 @@
         "location": "Gallwitzallee 88 12249 Berlin",
         "telephone": null,
         "details_url": "http://www.teststation-lankwitz.de/",
-        "opening_hours": "Mo 08:00 - 16:00; Tu 08:00 - 16:00; We 08:00 - 16:00; Th 08:00 - 16:00; Fr 08:00 - 16:00; Sa 08:00 - 16:00; Su 08:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 16:00; Tu 08:00 - 16:00; We 08:00 - 16:00; Th 08:00 - 16:00; Fr 08:00 - 16:00; Sa 08:00 - 16:00; Su 08:00 - 16:00",
         "title": "Teststation-Lankwitz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10909,7 +10909,7 @@
         "location": "Alt-Buckow 13 12349 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Teststelle Alt-Buckow",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10931,7 +10931,7 @@
         "location": "Friedrichstr. 76-78  10117  Berlin",
         "telephone": null,
         "details_url": "https://testedichschnell.de/teststelle-berlin-mitte/",
-        "opening_hours": "Mo 11:00 - 19:00; Tu 11:00 - 19:00; We 11:00 - 19:00; Th 11:00 - 19:00; Fr 11:00 - 19:00; Sa 11:00 - 19:00; ",
+        "opening_hours": "Mo 11:00 - 19:00; Tu 11:00 - 19:00; We 11:00 - 19:00; Th 11:00 - 19:00; Fr 11:00 - 19:00; Sa 11:00 - 19:00",
         "title": "Teststelle Berlin Mitte",
         "hints": [
           "PCR-Nachtestung: mit",
@@ -10953,7 +10953,7 @@
         "location": "Breisgauer Str. 1 14129 Berlin",
         "telephone": null,
         "details_url": "https://www.stadtapotheke-berlin.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00",
         "title": "Teststelle Heilmann (Bus)",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -10975,7 +10975,7 @@
         "location": "Werbellinst. 42 12053  Berllin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00",
         "title": "Teststelle im Bürgerzentrum Neukölln",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -10997,7 +10997,7 @@
         "location": "Müllerstr. 33 13353 Berlin",
         "telephone": null,
         "details_url": "http://www.maerkische-apotheke-berlin.de/",
-        "opening_hours": "Mo 10:00 - 12:00,15:00 - 17:00; Tu 10:00 - 12:00,15:00 - 17:00; We 10:00 - 12:00,15:00 - 17:00; Th 10:00 - 12:00,15:00 - 17:00; Fr 10:00 - 12:00,15:00 - 17:00; ",
+        "opening_hours": "Mo 10:00 - 12:00,15:00 - 17:00; Tu 10:00 - 12:00,15:00 - 17:00; We 10:00 - 12:00,15:00 - 17:00; Th 10:00 - 12:00,15:00 - 17:00; Fr 10:00 - 12:00,15:00 - 17:00",
         "title": "Teststelle in der Märkischen Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11019,7 +11019,7 @@
         "location": "Eichhorster Weg 91 13435  Berlin",
         "telephone": null,
         "details_url": "https://www.laatzig.de/",
-        "opening_hours": "Mo 07:00 - 10:00,15:00 - 17:00; Tu 07:00 - 10:00,15:00 - 17:00; We 07:00 - 10:00,15:00 - 17:00; Th 07:00 - 10:00,15:00 - 17:00; Fr 07:00 - 10:00,15:00 - 17:00; ",
+        "opening_hours": "Mo 07:00 - 10:00,15:00 - 17:00; Tu 07:00 - 10:00,15:00 - 17:00; We 07:00 - 10:00,15:00 - 17:00; Th 07:00 - 10:00,15:00 - 17:00; Fr 07:00 - 10:00,15:00 - 17:00",
         "title": "Teststelle Laatzig",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11041,7 +11041,7 @@
         "location": "Brunowstr. 41 13507 Berlin",
         "telephone": null,
         "details_url": "https://www.physiotegel.de/",
-        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 09:00 - 16:00; Su 09:00 - 16:00; ",
+        "opening_hours": "Mo 09:00 - 16:00; Tu 09:00 - 16:00; We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 09:00 - 16:00; Su 09:00 - 16:00",
         "title": "Teststelle Tegel",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11063,7 +11063,7 @@
         "location": "Pankower Allee 3 13409 Berlin",
         "telephone": null,
         "details_url": "https://coronateststation-residenzstrasse.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00",
         "title": "Teststelle: Kastanienwäldchen - Norbert Raeder",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11085,7 +11085,7 @@
         "location": "Herzbergstr. 56 10365 Berlin",
         "telephone": null,
         "details_url": "https://testvan.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00",
         "title": "Testvan.de / Teststelle Lichtenberg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11107,7 +11107,7 @@
         "location": "Lübbenerstrasse 63 10997  Berlin",
         "telephone": null,
         "details_url": "https://testyou.berlin/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 10:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 10:00 - 19:00",
         "title": "testyou.berlin Lübbenerstr.",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11129,7 +11129,7 @@
         "location": "Husemannstraße 17 10435 Berlin",
         "telephone": null,
         "details_url": "https://testzentrale.berlin",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00",
         "title": "Testzentrale Husemannstraße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11151,7 +11151,7 @@
         "location": "Frankfurter Allee 111 10247 Berlin",
         "telephone": null,
         "details_url": "http://termin.testzentrale.online/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00",
         "title": "Testzentrale Ring Center 1 im 2.OG",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11173,7 +11173,7 @@
         "location": "Sonnenallee 61 12045 Berlin",
         "telephone": null,
         "details_url": "https://testzentrale.berlin",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00",
         "title": "Testzentrale Sonnenallee",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11195,7 +11195,7 @@
         "location": "Alt-Rudow 60A 12355 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-alt-rudow/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Alt-Rudow",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11217,7 +11217,7 @@
         "location": "Lindenstr. 18-19 12555 Berlin",
         "telephone": null,
         "details_url": "https://www.testzentrum-af.berlin",
-        "opening_hours": "Mo 08:00 - 17:00; Tu 08:00 - 17:00; We 08:00 - 17:00; Th 08:00 - 17:00; Fr 08:00 - 17:00; ",
+        "opening_hours": "Mo 08:00 - 17:00; Tu 08:00 - 17:00; We 08:00 - 17:00; Th 08:00 - 17:00; Fr 08:00 - 17:00",
         "title": "Testzentrum Alte Försterei",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11239,7 +11239,7 @@
         "location": "Bahnhofstr. 39-40 12555 Berlin",
         "telephone": null,
         "details_url": "https://www.müggelturm.berlin/",
-        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 06:00 - 20:00; ",
+        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 06:00 - 20:00",
         "title": "Testzentrum am Forum Köpenick",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11261,7 +11261,7 @@
         "location": "Frankfuter Allee 7 10247 Berlin",
         "telephone": null,
         "details_url": "https://www.amano-ristorante.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "Testzentrum am Frankfuter Tor",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11283,7 +11283,7 @@
         "location": "Spreewaldplatz 5 10999 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Testzentrum am Görli",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11305,7 +11305,7 @@
         "location": "Turmstraße. 8 10559 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; Sa 07:00 - 18:00; Su 07:00 - 18:00; ",
+        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; Sa 07:00 - 18:00; Su 07:00 - 18:00",
         "title": "Testzentrum am Kriminalgericht",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11327,7 +11327,7 @@
         "location": "Nazarethkirchstr. 50 13347 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00",
         "title": "Testzentrum am Leopoldplatz",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11349,7 +11349,7 @@
         "location": "Eichborndamm 236 13437 Berlin",
         "telephone": null,
         "details_url": "http://www.testzentrum-reinickendorf.de/",
-        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; Sa 07:00 - 18:00; Su 09:00 - 13:00; ",
+        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; Sa 07:00 - 18:00; Su 09:00 - 13:00",
         "title": "Testzentrum am Reinickendorfer Park",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11371,7 +11371,7 @@
         "location": "Bänschstr. 51 10247 Berlin",
         "telephone": null,
         "details_url": "http://www.kinderarzt-dr-lueder.de/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00",
         "title": "Testzentrum Bänschstraße",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11393,7 +11393,7 @@
         "location": "Spreetalallee 1 14050  Berlin",
         "telephone": null,
         "details_url": "http://www.testzentrum-berlin-charlottenburg.de",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Testzentrum Berlin Charlottenburg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11415,7 +11415,7 @@
         "location": "Treskowallee 8 10318 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-berlin-lichtenberg/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Berlin Lichtenberg",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11437,7 +11437,7 @@
         "location": "Groscurthstr. 29-33 13125 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-berlin-nord/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Berlin Nord",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11459,7 +11459,7 @@
         "location": "Fischerstraße 36 10317 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-berlin-ost/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Berlin Ost",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11481,7 +11481,7 @@
         "location": "Am Juliusturm 64 13599 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-berlin-spandau/",
-        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; Su 10:00 - 20:00; ",
+        "opening_hours": "Mo 10:00 - 20:00; Tu 10:00 - 20:00; We 10:00 - 20:00; Th 10:00 - 20:00; Fr 10:00 - 20:00; Sa 10:00 - 20:00; Su 10:00 - 20:00",
         "title": "Testzentrum Berlin Spandau",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11503,7 +11503,7 @@
         "location": "Franzensbader Str. 16 14193 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-berlin-west/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Berlin West",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11525,7 +11525,7 @@
         "location": "Poststadion Lehrter Str. 59 10557 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-berlin-zentral",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Berlin Zentral",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11547,7 +11547,7 @@
         "location": "Alt-Stralau 70 10245 Berlin",
         "telephone": null,
         "details_url": "https://testzentrum-berlin-brandenburg.de/",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Testzentrum Berlin-Friedrichshain (Renate)",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11569,7 +11569,7 @@
         "location": "Molkenmarkt 2 10179 Berlin",
         "telephone": null,
         "details_url": "https://testzentrum-berlin-mitte.de/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "Testzentrum Berlin-Mitte",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11591,7 +11591,7 @@
         "location": "Karl-Marx-Strasse 131 12043 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 12:00 - 20:00; Tu 12:00 - 20:00; We 12:00 - 20:00; Th 12:00 - 20:00; Fr 12:00 - 20:00; ",
+        "opening_hours": "Mo 12:00 - 20:00; Tu 12:00 - 20:00; We 12:00 - 20:00; Th 12:00 - 20:00; Fr 12:00 - 20:00",
         "title": "Testzentrum BG in den Passagen",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11613,7 +11613,7 @@
         "location": "Feldberger Ring 5 12619  Berlin",
         "telephone": "030 56400198",
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 16:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 16:00",
         "title": "Testzentrum Bowling Hellersdorf",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11635,7 +11635,7 @@
         "location": "Goerzallee 299 14167 Berlin",
         "telephone": null,
         "details_url": "https://sites.google.com/view/testzentrum-leder",
-        "opening_hours": "Mo 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00",
         "title": "Testzentrum Burkhard Leder",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11657,7 +11657,7 @@
         "location": "Zillestr. 10 10585 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-charlottenburg/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Charlottenburg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11679,7 +11679,7 @@
         "location": "Mauerstraße 79 10117 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-checkpoint-charlie/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Checkpoint Charlie",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11701,7 +11701,7 @@
         "location": "Wormser Str. 4 10789 Berlin",
         "telephone": "030 66400082",
         "details_url": "http://www.testzentrum-city-west.de",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00",
         "title": "Testzentrum City West",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11723,7 +11723,7 @@
         "location": "Danziger Str. 100 10405 Berlin",
         "telephone": null,
         "details_url": "https://danziger-schnelltest.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00",
         "title": "Testzentrum Danziger Str. 100",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11745,7 +11745,7 @@
         "location": "Senftenberger Ring 5a 13439 Berlin",
         "telephone": null,
         "details_url": "http://www.grosskreuz-apotheke.de/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00",
         "title": "Testzentrum der Großkreuz-Apotheke im Märkischen Viertel",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11767,7 +11767,7 @@
         "location": "Pasewalkerstr. 8 13347 Berlin",
         "telephone": null,
         "details_url": "http://www.zahnarztpraxis-drkunze.de/",
-        "opening_hours": "Mo 09:00 - 12:00,14:00 - 18:00; Tu 09:00 - 12:00,14:00 - 18:00; We 09:00 - 12:00,14:00 - 18:00; Th 09:00 - 12:00,14:00 - 18:00; Fr 09:00 - 12:00,14:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 12:00,14:00 - 18:00; Tu 09:00 - 12:00,14:00 - 18:00; We 09:00 - 12:00,14:00 - 18:00; Th 09:00 - 12:00,14:00 - 18:00; Fr 09:00 - 12:00,14:00 - 18:00",
         "title": "Testzentrum Dr. Kunze",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11789,7 +11789,7 @@
         "location": "Schnellerstr. 21 12439 Berlin",
         "telephone": null,
         "details_url": "https://europa-apo-berlin.probatix.de/de/pick-slot ",
-        "opening_hours": "Mo 09:03 - 18:00; Tu 09:30 - 18:00; We 09:30 - 18:00; Th 09:30 - 18:00; Fr 09:30 - 18:00; ",
+        "opening_hours": "Mo 09:03 - 18:00; Tu 09:30 - 18:00; We 09:30 - 18:00; Th 09:30 - 18:00; Fr 09:30 - 18:00",
         "title": "Testzentrum europa apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11811,7 +11811,7 @@
         "location": "Hardenbergplatz 15 10623 Berlin",
         "telephone": null,
         "details_url": "https://www.stadtapotheke-berlin.de/",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 09:00 - 19:00",
         "title": "Testzentrum Hardenbergplatz-Zoo",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11833,7 +11833,7 @@
         "location": "Alt Heiligensee 45/47 13503 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-heiligensee",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Heiligensee",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11855,7 +11855,7 @@
         "location": "Obstallee 28 13593 Berlin",
         "telephone": null,
         "details_url": "https://www.zentrumapotheke.de/website/",
-        "opening_hours": "Mo 10:00 - 13:00,16:00 - 18:00; Tu 10:00 - 13:00,16:00 - 18:00; We 10:00 - 13:00,16:00 - 18:00; Th 10:00 - 13:00,16:00 - 18:00; Fr 10:00 - 13:00,16:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 13:00,16:00 - 18:00; Tu 10:00 - 13:00,16:00 - 18:00; We 10:00 - 13:00,16:00 - 18:00; Th 10:00 - 13:00,16:00 - 18:00; Fr 10:00 - 13:00,16:00 - 18:00",
         "title": "Testzentrum im Staakencenter ",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11877,7 +11877,7 @@
         "location": "Kopenhagener Str. 16 10437 Berlin",
         "telephone": null,
         "details_url": "http://coronatestprenzlauerberg.de",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 12:00 - 20:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 12:00 - 20:00",
         "title": "Testzentrum in der Kohlenquelle im Prenzlauer Berg",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11899,7 +11899,7 @@
         "location": "Rohrwallallee 71 12527  Berlin",
         "telephone": "0157 51100248",
         "details_url": "",
-        "opening_hours": "Mo 16:00 - 18:00; We 16:00 - 18:00; Fr 16:00 - 18:00; ",
+        "opening_hours": "Mo 16:00 - 18:00; We 16:00 - 18:00; Fr 16:00 - 18:00",
         "title": "Testzentrum Karolinenhof SGK e.V.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11921,7 +11921,7 @@
         "location": "Schlesische Str. 37 10997 Berlin",
         "telephone": "0152 54836562",
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 15:00; Tu 09:00 - 15:00; We 09:00 - 15:00; Th 09:00 - 15:00; Fr 09:00 - 15:00; ",
+        "opening_hours": "Mo 09:00 - 15:00; Tu 09:00 - 15:00; We 09:00 - 15:00; Th 09:00 - 15:00; Fr 09:00 - 15:00",
         "title": "Testzentrum Kreuzberg an der Palmen Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -11943,7 +11943,7 @@
         "location": "Schleusenufer 3 10997 Berlin",
         "telephone": null,
         "details_url": "https://testzentrum-berlin-brandenburg.de/terminbuchung/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "Testzentrum Kreuzberg Schleusenufer",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11965,7 +11965,7 @@
         "location": "Celsiusstrasse 60 12207 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-lichterfelde-sued",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Lichterfelde Süd",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -11987,7 +11987,7 @@
         "location": "Frankenholzer Weg 4 12683 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-marzahn-biesdorf/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Marzahn-Biesdorf",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12009,7 +12009,7 @@
         "location": "Jänschwalderstr. 4 12627 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-marzahn-hellersdorf/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Marzahn-Hellersdorf",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12031,7 +12031,7 @@
         "location": "Wolfener Str. 32-34 12681  Berlin",
         "telephone": "030 930222123",
         "details_url": "http://www.medical.dispotf.de/",
-        "opening_hours": "Mo 08:00 - 14:00; Tu 08:00 - 14:00; We 08:00 - 14:00; Th 08:00 - 14:00; Fr 08:00 - 14:00; ",
+        "opening_hours": "Mo 08:00 - 14:00; Tu 08:00 - 14:00; We 08:00 - 14:00; Th 08:00 - 14:00; Fr 08:00 - 14:00",
         "title": "Testzentrum Medical & Safety Marzahn",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12053,7 +12053,7 @@
         "location": "Elisabeth-Abegg-Straße 1 10557 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-mitte/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Mitte",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12075,7 +12075,7 @@
         "location": "Leinestraße 37-45 12049 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-neukoelln2/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Neukölln 2",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12097,7 +12097,7 @@
         "location": "Hohenzollernplatz 6 14129  Berlin",
         "telephone": null,
         "details_url": "https://testtermin.de/nikolassee",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 10:00 - 17:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 10:00 - 17:00",
         "title": "Testzentrum Nikolassee",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12119,7 +12119,7 @@
         "location": "Bevernstraße 5 10997 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 08:00 - 20:00",
         "title": "Testzentrum Oberbaumeck",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12141,7 +12141,7 @@
         "location": "Holteistraße 6-9 10245  Berlin",
         "telephone": null,
         "details_url": "https://testzentrum-berlin-brandenburg.de/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "Testzentrum Ostkreuz",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12163,7 +12163,7 @@
         "location": "Wilhelmstr.15  10963  Berlin",
         "telephone": null,
         "details_url": "https://covidtest-sofort.de/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00",
         "title": "Testzentrum Pane Wilhelmstrasse",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12185,7 +12185,7 @@
         "location": "Breite Str. 33-34 13187  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 10:00 - 19:00; Su 10:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 10:00 - 19:00; Su 10:00 - 19:00",
         "title": "Testzentrum Pankow",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12207,7 +12207,7 @@
         "location": "Eichborndamm 97 13403  Berlin",
         "telephone": null,
         "details_url": "https://www.testzentrumroyal.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00",
         "title": "Testzentrum Reinickendorf",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12229,7 +12229,7 @@
         "location": "Senftenberger Ring 3a 13439 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-reinickendorf-2/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Reinickendorf 2 (in der AOK)",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12251,7 +12251,7 @@
         "location": "Am Juliusturm 55-59 13599 Berlin",
         "telephone": null,
         "details_url": "https://calendly.com/testzentrumroyaltermin",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00",
         "title": "Testzentrum Royal",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12273,7 +12273,7 @@
         "location": "Bismarckstraße 110 10625 Berlin",
         "telephone": null,
         "details_url": "https://komoedie-coronatest.de/",
-        "opening_hours": "We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 09:00 - 16:00; Su 09:00 - 16:00; ",
+        "opening_hours": "We 09:00 - 16:00; Th 09:00 - 16:00; Fr 09:00 - 16:00; Sa 09:00 - 16:00; Su 09:00 - 16:00",
         "title": "Testzentrum Schiller Theater",
         "hints": [
           "PCR-Nachtestung: mit",
@@ -12295,7 +12295,7 @@
         "location": "Provinzstr. 40  13409  Berlin",
         "telephone": null,
         "details_url": "https://www.testzentrum-franchise.de/testzentrum-schönholz-termin",
-        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 00:30 - 19:00; ",
+        "opening_hours": "Mo 09:00 - 19:00; Tu 09:00 - 19:00; We 09:00 - 19:00; Th 09:00 - 19:00; Fr 09:00 - 19:00; Sa 09:00 - 19:00; Su 00:30 - 19:00",
         "title": "Testzentrum Schönholz",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12317,7 +12317,7 @@
         "location": "Sprengelstr.21 13353 Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 11:00; Tu 09:00 - 11:00; We 09:00 - 11:00; Th 09:00 - 11:00; Fr 09:00 - 11:00; ",
+        "opening_hours": "Mo 09:00 - 11:00; Tu 09:00 - 11:00; We 09:00 - 11:00; Th 09:00 - 11:00; Fr 09:00 - 11:00",
         "title": "Testzentrum Sprengelstr.",
         "hints": [
           "PCR-Nachtestung: mit",
@@ -12339,7 +12339,7 @@
         "location": "Gardes-Du-Corps-Strasse 10 14059 Berlin",
         "telephone": "030 21965143",
         "details_url": "",
-        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 09:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 20:00; Tu 08:00 - 20:00; We 08:00 - 20:00; Th 08:00 - 20:00; Fr 08:00 - 20:00; Sa 08:00 - 20:00; Su 09:00 - 18:00",
         "title": "TESTZENTRUM STAR MEDICAL",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12361,7 +12361,7 @@
         "location": "Schlossstraße 120 12163 Berlin",
         "telephone": null,
         "details_url": "https://schnelltestberlin.de/buergertest-steglitz/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "Testzentrum Steglitz",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12383,7 +12383,7 @@
         "location": "Am Borsigturm 5 13507  Berlin",
         "telephone": null,
         "details_url": "http://www.testzentrum-tegel.de/",
-        "opening_hours": "Mo 06:30 - 19:00; Tu 06:30 - 19:00; We 06:30 - 19:00; Th 06:30 - 19:00; Fr 06:30 - 19:00; Sa 06:30 - 19:00; ",
+        "opening_hours": "Mo 06:30 - 19:00; Tu 06:30 - 19:00; We 06:30 - 19:00; Th 06:30 - 19:00; Fr 06:30 - 19:00; Sa 06:30 - 19:00",
         "title": "Testzentrum Tegel",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12405,7 +12405,7 @@
         "location": "Mariendorfer Damm 64 12109 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-tempelhof-schoeneberg/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 19:00",
         "title": "Testzentrum Tempelhof-Schöneberg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12427,7 +12427,7 @@
         "location": "Hasselwerderstrasse 38-40 12439 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-treptow-koepenick-2/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Treptow-Köpenick 2",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12449,7 +12449,7 @@
         "location": "Unter den Linden 42 10117 Berlin",
         "telephone": null,
         "details_url": "https://www.stadtapotheke-berlin.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 10:00 - 17:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 10:00 - 17:00",
         "title": "Testzentrum Unter den Linden",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12471,7 +12471,7 @@
         "location": "Müllerstr. 143 13353 Berlin",
         "telephone": null,
         "details_url": "https://test-to-go.berlin/testzentrum-wedding-2/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; Sa 08:00 - 18:00; Su 08:00 - 18:00",
         "title": "Testzentrum Wedding 2 (in der AOK)",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12493,7 +12493,7 @@
         "location": "Oranienburger Str.88 13437  Berlin",
         "telephone": "0178 5358792",
         "details_url": "http://testzentrum-wittenau.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:00 - 18:00",
         "title": "Testzentrum Wittenau",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12515,7 +12515,7 @@
         "location": "Burgfrauenstrasse 1 13465 Berlin",
         "telephone": null,
         "details_url": "https://coronatest-frohnau.de/",
-        "opening_hours": "Mo 09:00 - 12:00,15:00 - 17:00; Tu 09:00 - 12:00,15:00 - 17:00; We 09:00 - 12:00,15:00 - 17:00; Th 09:00 - 12:00,15:00 - 17:00; Fr 09:00 - 12:00,15:00 - 17:00; Sa 09:00 - 12:00; ",
+        "opening_hours": "Mo 09:00 - 12:00,15:00 - 17:00; Tu 09:00 - 12:00,15:00 - 17:00; We 09:00 - 12:00,15:00 - 17:00; Th 09:00 - 12:00,15:00 - 17:00; Fr 09:00 - 12:00,15:00 - 17:00; Sa 09:00 - 12:00",
         "title": "testzentrum Wochenmarkt Frohnau",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12537,7 +12537,7 @@
         "location": "Marienfelder Chaussee 170 12349 Berlin",
         "telephone": null,
         "details_url": "https://www.comfort-homecare.de/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00",
         "title": "Testzentrum WVV Gesundheitsnetzwerk",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12559,7 +12559,7 @@
         "location": "Gneisenaustr. 92 10961 Berlin",
         "telephone": null,
         "details_url": "https://kaiser-apotheke-berlin.easy2book.de/",
-        "opening_hours": "Mo 09:00 - 12:00; Tu 09:00 - 12:00; We 09:00 - 12:00; Th 09:00 - 12:00; Fr 09:00 - 12:00; ",
+        "opening_hours": "Mo 09:00 - 12:00; Tu 09:00 - 12:00; We 09:00 - 12:00; Th 09:00 - 12:00; Fr 09:00 - 12:00",
         "title": "Testzentrum zum Goldenen Einhorn Kreuzberg/Gneisenaustraße",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12581,7 +12581,7 @@
         "location": "Budapester Str. 50  (Rooftop 2. Etage) 10787 Berlin",
         "telephone": null,
         "details_url": "https://schnelltestberlin.de/Bikini/",
-        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00; ",
+        "opening_hours": "Mo 07:00 - 20:00; Tu 07:00 - 20:00; We 07:00 - 20:00; Th 07:00 - 20:00; Fr 07:00 - 20:00; Sa 07:00 - 20:00; Su 07:00 - 20:00",
         "title": "Testzentrum | Bikini Berlin",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12603,7 +12603,7 @@
         "location": "Saalestraße 16 12055 Berlin",
         "telephone": null,
         "details_url": "https://www.testzentrum-neukölln.de/termin",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00",
         "title": "Testzentrum-Neukölln",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12625,7 +12625,7 @@
         "location": "Gartenfelder Str. 29-37  13599  Berlin",
         "telephone": null,
         "details_url": "https://thalion.digital/",
-        "opening_hours": "Mo 09:00 - 14:00; We 09:00 - 14:00; Fr 09:00 - 14:00; ",
+        "opening_hours": "Mo 09:00 - 14:00; We 09:00 - 14:00; Fr 09:00 - 14:00",
         "title": "Thalion Professional Care School",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12647,7 +12647,7 @@
         "location": "Uhlandstr 124 10717  Berlin",
         "telephone": null,
         "details_url": "https://gutachtennwp.de/",
-        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; Sa 07:00 - 18:00; Su 07:00 - 18:00; ",
+        "opening_hours": "Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00; Th 07:00 - 18:00; Fr 07:00 - 18:00; Sa 07:00 - 18:00; Su 07:00 - 18:00",
         "title": "Therapiezentrum -Uhland 124",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12669,7 +12669,7 @@
         "location": "Siemensdamm 43 13629 Berlin",
         "telephone": null,
         "details_url": "https://gutachtennwp.de/",
-        "opening_hours": "Mo 00:00 - 23:59; Tu 00:00 - 23:59; We 00:00 - 23:59; Th 00:00 - 23:59; Fr 00:00 - 23:59; Sa 00:00 - 23:59; Su 00:00 - 23:59; ",
+        "opening_hours": "Mo 00:00 - 23:59; Tu 00:00 - 23:59; We 00:00 - 23:59; Th 00:00 - 23:59; Fr 00:00 - 23:59; Sa 00:00 - 23:59; Su 00:00 - 23:59",
         "title": "Therapiezentrum Drive IN Siemensdamm",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12691,7 +12691,7 @@
         "location": "Edenkobener Weg 75 12247 Berlin",
         "telephone": null,
         "details_url": "https://tuslihockey.de/",
-        "opening_hours": "Tu 08:00 - 10:00,17:00 - 19:00; Th 08:00 - 10:00,17:00 - 19:00; ",
+        "opening_hours": "Tu 08:00 - 10:00,17:00 - 19:00; Th 08:00 - 10:00,17:00 - 19:00",
         "title": "TuS Li testet",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12713,7 +12713,7 @@
         "location": "Karl Marx Str.78 12043 Berlin",
         "telephone": null,
         "details_url": "http://www.twttestzentrum.de/",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 10:00 - 18:00",
         "title": "TWT Corona Testzentrum  ",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12735,7 +12735,7 @@
         "location": "Stralauer Allee 3 10245 Berlin",
         "telephone": null,
         "details_url": "https://coronatest24.org/termin-buchen/#/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 14:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 14:00",
         "title": "U-bhf Warschauerstraße Coronatest 24 Stralauer Allee NH Hotel",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12757,7 +12757,7 @@
         "location": "Bismarck Str. 26  10625  Berlin",
         "telephone": null,
         "details_url": "http://www.utteststation.de/",
-        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 06:00 - 20:00; Tu 06:00 - 20:00; We 06:00 - 20:00; Th 06:00 - 20:00; Fr 06:00 - 20:00; Sa 06:00 - 20:00; Su 10:00 - 18:00",
         "title": "UT Teststation",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12779,7 +12779,7 @@
         "location": "Platz des 4. Juli,  14167  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 07:30 - 18:00; Tu 07:30 - 18:00; We 07:30 - 18:00; Th 07:30 - 18:00; Fr 07:30 - 18:00; Sa 07:30 - 18:00; ",
+        "opening_hours": "Mo 07:30 - 18:00; Tu 07:30 - 18:00; We 07:30 - 18:00; Th 07:30 - 18:00; Fr 07:30 - 18:00; Sa 07:30 - 18:00",
         "title": "Valabel Test Now Service",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12801,7 +12801,7 @@
         "location": "Kleiststraße 34 10787 Berlin",
         "telephone": "030 2181338",
         "details_url": "http://www.viapharm-apotheke.de/",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00",
         "title": "Viapharm Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12823,7 +12823,7 @@
         "location": "Wiltbergstr. 25 13125 Berlin",
         "telephone": null,
         "details_url": "https://www.ecocare.center/apotheken/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00",
         "title": "Viereck-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12845,7 +12845,7 @@
         "location": "Alt Mariendorf 45   12107 Berlin",
         "telephone": null,
         "details_url": "https://covidtest-sofort.de/",
-        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00; ",
+        "opening_hours": "Mo 09:00 - 17:00; Tu 09:00 - 17:00; We 09:00 - 17:00; Th 09:00 - 17:00; Fr 09:00 - 17:00; Sa 09:00 - 17:00; Su 09:00 - 17:00",
         "title": "Villa Lakerda",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12867,7 +12867,7 @@
         "location": "Marchwitzastr. 31 12681 Berlin",
         "telephone": null,
         "details_url": "https://www.vitacura-apotheke-berlin.de/",
-        "opening_hours": "Mo 10:00 - 13:00,14:00 - 17:00; Tu 10:00 - 13:00,14:00 - 17:00; We 10:00 - 13:00,14:00 - 17:00; Th 10:00 - 13:00,14:00 - 17:00; Fr 10:00 - 13:00,14:00 - 17:00; ",
+        "opening_hours": "Mo 10:00 - 13:00,14:00 - 17:00; Tu 10:00 - 13:00,14:00 - 17:00; We 10:00 - 13:00,14:00 - 17:00; Th 10:00 - 13:00,14:00 - 17:00; Fr 10:00 - 13:00,14:00 - 17:00",
         "title": "VitaCura-Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12889,7 +12889,7 @@
         "location": "Skalitzer Str. 15-17 10999 Berlin",
         "telephone": null,
         "details_url": "https://www.vital-apotheke-berlin.de",
-        "opening_hours": "Mo 09:00 - 13:00; Tu 09:00 - 13:00; We 09:00 - 13:00; Th 09:00 - 13:00; Fr 09:00 - 13:00; Sa 09:00 - 13:00; ",
+        "opening_hours": "Mo 09:00 - 13:00; Tu 09:00 - 13:00; We 09:00 - 13:00; Th 09:00 - 13:00; Fr 09:00 - 13:00; Sa 09:00 - 13:00",
         "title": "Vital Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12911,7 +12911,7 @@
         "location": "Rudower Str. 48 12351  Berlin",
         "telephone": null,
         "details_url": "https://termin.vivantes.de/Corona-Testung/",
-        "opening_hours": "Mo 08:00 - 16:30; Tu 08:00 - 16:30; We 08:00 - 16:30; Th 08:00 - 16:30; Fr 08:00 - 16:30; ",
+        "opening_hours": "Mo 08:00 - 16:30; Tu 08:00 - 16:30; We 08:00 - 16:30; Th 08:00 - 16:30; Fr 08:00 - 16:30",
         "title": "Vivantes Klinikum Neukölln",
         "hints": [
           "PCR-Nachtestung: moeglich",
@@ -12933,7 +12933,7 @@
         "location": "Neue Bergstraße 6 13585 Berlin",
         "telephone": null,
         "details_url": "https://termin.vivantes.de/Corona-Testung/",
-        "opening_hours": "Mo 09:30 - 15:00; Tu 09:30 - 15:00; We 09:30 - 15:00; Th 09:30 - 15:00; Fr 09:30 - 15:00; Sa 09:30 - 15:00; Su 09:30 - 15:00; ",
+        "opening_hours": "Mo 09:30 - 15:00; Tu 09:30 - 15:00; We 09:30 - 15:00; Th 09:30 - 15:00; Fr 09:30 - 15:00; Sa 09:30 - 15:00; Su 09:30 - 15:00",
         "title": "Vivantes Klinikum Spandau",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12955,7 +12955,7 @@
         "location": "Fröbelstraße 15 10405 Berlin",
         "telephone": null,
         "details_url": "https://termin.vivantes.de/Corona-Testung/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00",
         "title": "Vivantes Prenzlauer Berg",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12977,7 +12977,7 @@
         "location": "Wenckebachstraße 23 12099 Berlin",
         "telephone": null,
         "details_url": "https://termin.vivantes.de/Corona-Testung/",
-        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00; ",
+        "opening_hours": "Mo 08:00 - 19:00; Tu 08:00 - 19:00; We 08:00 - 19:00; Th 08:00 - 19:00; Fr 08:00 - 19:00; Sa 08:00 - 19:00; Su 08:00 - 19:00",
         "title": "Vivantes Wenckebach-Klinikum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -12999,7 +12999,7 @@
         "location": "Hanns-Braun-Str. 0 14053 Berlin",
         "telephone": null,
         "details_url": "https://spandau04.de/service/corona-testzentrum/",
-        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00; ",
+        "opening_hours": "Mo 08:00 - 18:00; Tu 08:00 - 18:00; We 08:00 - 18:00; Th 08:00 - 18:00; Fr 08:00 - 18:00",
         "title": "Wasserfreunde Spandau 04 Testzentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -13021,7 +13021,7 @@
         "location": "Spandauer Damm 130 14050 Berlin",
         "telephone": null,
         "details_url": "http://www.westend-apotheke-berlin.de/",
-        "opening_hours": "Mo 09:00 - 13:30; Tu 09:00 - 13:30; We 09:00 - 13:30; Th 09:00 - 13:30; Fr 09:00 - 13:30; Sa 09:00 - 12:30; ",
+        "opening_hours": "Mo 09:00 - 13:30; Tu 09:00 - 13:30; We 09:00 - 13:30; Th 09:00 - 13:30; Fr 09:00 - 13:30; Sa 09:00 - 12:30",
         "title": "Westend Apotheke Test to go",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -13043,7 +13043,7 @@
         "location": "Dircksenstr. Bogen 114 10178  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00",
         "title": "Wettarena Schnelltest Zentrum Dircksenstr.",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -13065,7 +13065,7 @@
         "location": "Hasenheide 107 10967  Berlin",
         "telephone": null,
         "details_url": "",
-        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00; ",
+        "opening_hours": "Mo 09:00 - 20:00; Tu 09:00 - 20:00; We 09:00 - 20:00; Th 09:00 - 20:00; Fr 09:00 - 20:00; Sa 09:00 - 20:00; Su 09:00 - 20:00",
         "title": "Wettarena Schnelltest Zentrum Hasenheide",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -13087,7 +13087,7 @@
         "location": "Sonnenallee 105 12045 Berlin",
         "telephone": "030 6872124",
         "details_url": "https://www.wildenbruch-apotheke-berlin.de/website/",
-        "opening_hours": "Mo 09:00 - 18:30; Tu 09:00 - 18:30; We 09:00 - 18:30; Th 09:00 - 18:30; Fr 09:00 - 18:30; Sa 10:30 - 16:30; ",
+        "opening_hours": "Mo 09:00 - 18:30; Tu 09:00 - 18:30; We 09:00 - 18:30; Th 09:00 - 18:30; Fr 09:00 - 18:30; Sa 10:30 - 16:30",
         "title": "Wildenbruch Apotheke",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -13109,7 +13109,7 @@
         "location": "Königin-Elisabeth-Str. 1 14057 Berlin",
         "telephone": null,
         "details_url": "https://www.witzleben-apotheke.de/",
-        "opening_hours": "Mo 10:00 - 15:00; Tu 10:00 - 15:00; We 10:00 - 15:00; Th 10:00 - 15:00; Fr 10:00 - 15:00; ",
+        "opening_hours": "Mo 10:00 - 15:00; Tu 10:00 - 15:00; We 10:00 - 15:00; Th 10:00 - 15:00; Fr 10:00 - 15:00",
         "title": "Witzleben Apotheke 26",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -13131,7 +13131,7 @@
         "location": "Wittestr. 26c 13509 Berlin",
         "telephone": null,
         "details_url": "https://workforceandcare.de/",
-        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00; ",
+        "opening_hours": "Mo 10:00 - 18:00; Tu 10:00 - 18:00; We 10:00 - 18:00; Th 10:00 - 18:00; Fr 10:00 - 18:00; Sa 10:00 - 18:00; Su 10:00 - 18:00",
         "title": "Workforce and Care",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -13153,7 +13153,7 @@
         "location": "Buckower Damm 30 / Haus 2 EG 12349  Berlin",
         "telephone": "030 7700070",
         "details_url": "https://www.wowi-haustechnik.de/",
-        "opening_hours": "Mo 07:00 - 15:00; Tu 07:00 - 15:00; We 07:00 - 15:00; Th 07:00 - 15:00; Fr 07:00 - 15:00; ",
+        "opening_hours": "Mo 07:00 - 15:00; Tu 07:00 - 15:00; We 07:00 - 15:00; Th 07:00 - 15:00; Fr 07:00 - 15:00",
         "title": "WOWI-Teststelle",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -13175,7 +13175,7 @@
         "location": "Teltower Damm 19 14169  Berlin",
         "telephone": null,
         "details_url": "https://www.zehlendorf-apotheke.de/apotheke/willkommen.htm",
-        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:30 - 15:30; ",
+        "opening_hours": "Mo 09:00 - 18:00; Tu 09:00 - 18:00; We 09:00 - 18:00; Th 09:00 - 18:00; Fr 09:00 - 18:00; Sa 09:30 - 15:30",
         "title": "Zehlendorf Apotheke Testzentrum",
         "hints": [
           "PCR-Nachtestung: nein",
@@ -13197,7 +13197,7 @@
         "location": "An der Apostelkirche 1 10783  Berlin",
         "telephone": null,
         "details_url": "http://quartier-apotheke.de/",
-        "opening_hours": "Mo 10:00 - 15:00; Tu 10:00 - 15:00; We 10:00 - 15:00; Th 10:00 - 15:00; Fr 10:00 - 15:00; Sa 10:00 - 15:00; Su 10:00 - 15:00; ",
+        "opening_hours": "Mo 10:00 - 15:00; Tu 10:00 - 15:00; We 10:00 - 15:00; Th 10:00 - 15:00; Fr 10:00 - 15:00; Sa 10:00 - 15:00; Su 10:00 - 15:00",
         "title": "Zwölf-Apostel-Kirche",
         "hints": [
           "PCR-Nachtestung: nein",

--- a/preprocessing/berlin/compile-berlin-geojson.js
+++ b/preprocessing/berlin/compile-berlin-geojson.js
@@ -24,7 +24,7 @@ const weekDayMap = {
 
 const convertToOpeningHours = (openingString) => {
     const data = JSON.parse(openingString);
-    return Object.keys(data).reduce((agg, key) => {
+    const text = Object.keys(data).reduce((agg, key) => {
         const value = data[key];
         if (value === "0" || value === "1"){
             return agg;
@@ -32,6 +32,7 @@ const convertToOpeningHours = (openingString) => {
         agg += `${weekDayMap[key]} ${value.join(',')}; `;
         return agg;
     }, "");
+    return text.trim().replace(/;$/, '');
 };
 
 const appointmentMap = {


### PR DESCRIPTION
# Error

> Error: Mo 07:00 - 18:00; Tu 07:00 - 18:00; We 07:00 - 18:00;
  Th 07:00 - 18:00; Fr 07:00 - 18:00; Sa 07:00 - 18:00;
  Su 07:00 - 18:00;  <--- (This rule does not contain anything useful.
  Please remove this empty rule. Might it be possible that you are a
  programmer and adding a semicolon after each statement is hardwired
  in your muscle memory ;) ? The thing is that the semicolon in the
  opening_hours syntax is defined as rule separator. So for
  compatibility reasons you should omit this last semicolon.)