### PR TITLE
Fix node error when running preprocessor for Berlin.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,3 +1,3 @@
 {
-    "esversion": 6
+    "esversion": 8
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wo-ist-testzentrum",
   "version": "0.0.1",
+  "type": "module",
   "devDependencies": {
     "colors": "^1.4.0",
     "dayjs": "^1.10.7",

--- a/preprocessing/berlin/compile-berlin-geojson.js
+++ b/preprocessing/berlin/compile-berlin-geojson.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 "use strict";
 
-const fetch = require('node-fetch');
-const dayjs = require('dayjs');
+import fetch from "node-fetch";
+import dayjs from "dayjs";
 
 const URL = 'https://test-to-go.berlin/wp-admin/admin-ajax.php?action=asl_load_stores&nonce=3a3f19feff&load_all=1&layout=1';
 

--- a/spec/citylist-spec.js
+++ b/spec/citylist-spec.js
@@ -1,5 +1,5 @@
-var fs = require('fs'),
-    path = require('path');
+import fs from "fs";
+import path from "path";
 
 
 function normalizeString(string){
@@ -70,7 +70,7 @@ describe('CityList', function() {
                 key;
             for (var i = 0, n = keys.length; i < n; i++) {
                 key = keys[i];
-                city = cities[key];
+                var city = cities[key];
                 expect(key).toBe(city.id, "Key and id do not match");
             }
         });

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -7,5 +7,6 @@
     "helpers/**/*.js"
   ],
   "stopSpecOnExpectationFailure": false,
-  "random": false
+  "random": false,
+  "jsLoader": "import"
 }

--- a/validation/.jshintrc
+++ b/validation/.jshintrc
@@ -1,4 +1,5 @@
 {
+    "esversion": 8,
     "node": true,
     "globals": {
     	"URL": true

--- a/validation/testcenter-validator.js
+++ b/validation/testcenter-validator.js
@@ -13,14 +13,23 @@
  */
 
 
-var assert = require('assert');
-var fs = require('fs');
-var path = require("path");
-var colors = require('colors');
-var opening_hours = require('opening_hours');
-var http = require('http');
-var https = require('https');
-var pkg = require('../package.json');
+import assert from "assert";
+import fs from "fs";
+import path from "path";
+import colors from "colors";
+import opening_hours from "opening_hours";
+import http from "http";
+import https from "https";
+
+function loadPackageJson() {
+  const rootPath = fs.realpathSync(".");
+  const packageJsonPath = path.join(rootPath, "package.json");
+  const pkgFile = fs.readFileSync(packageJsonPath, "utf8");
+  const packageJson = JSON.parse(pkgFile);
+  return packageJson;
+}
+
+const pkg = loadPackageJson();
 
 /**
  * The repository URL is used in the user-agent header in the url


### PR DESCRIPTION
+ This fixes a _node_ error which occurs when running the preprocessor script for Berlin.
+ Switch to esm.

# Error output

``` bash
$ node preprocessing/berlin/compile-berlin-geojson.js > cities/berlin.json  
node:internal/modules/cjs/loader:1125
      throw new ERR_REQUIRE_ESM(filename, parentPath, packageJsonPath);
      ^

Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: wo-ist-testzentrum/node_modules/node-fetch/src/index.js
require() of ES modules is not supported.
require() of wo-ist-testzentrum/node_modules/node-fetch/src/index.js from 
  wo-ist-testzentrum/preprocessing/berlin/compile-berlin-geojson.js is an ES module file as it is a .js file
  whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope
  as ES modules.
Instead rename index.js to end in .cjs, change the requiring code to use import(), or remove "type": "module"
  from wo-ist-testzentrum/node_modules/node-fetch/package.json.

    at new NodeError (node:internal/errors:363:5)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1125:13)
    at Module.load (node:internal/modules/cjs/loader:988:32)
    at Function.Module._load (node:internal/modules/cjs/loader:828:14)
    at Module.require (node:internal/modules/cjs/loader:1012:19)
    at require (node:internal/modules/cjs/helpers:93:18)
    at Object.<anonymous> (wo-ist-testzentrum/preprocessing/berlin/compile-berlin-geojson.js:4:15)
    at Module._compile (node:internal/modules/cjs/loader:1108:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)
    at Module.load (node:internal/modules/cjs/loader:988:32) {
  code: 'ERR_REQUIRE_ESM'
}
```