### PR TITLE
Update data for Berlin (17.04.2022).

### DIFF
--- a/cities/berlin.json
+++ b/cities/berlin.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "data_source": {
-      "title": "Stadt Berlin, Stand: 20.02.2022",
+      "title": "Stadt Berlin, Stand: 17.04.2022",
       "url": "https://www.direkttesten.berlin"
     }
   },
@@ -56,29 +56,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.32526,
-          52.56512
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Scharnweberstr. 25, 13405 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Scharnweber25",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.38453,
           52.49858
         ],
@@ -89,7 +66,7 @@
         "telephone": null,
         "details_url": "https://schnell.coronatest.de",
         "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 09:00-18:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "(05) Gastmannschaft GmbH Tempelhofer Ufer",
+        "title": "Gastmannschaft GmbH Tempelhofer Ufer",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: keine Angabe",
@@ -112,7 +89,7 @@
         "telephone": null,
         "details_url": "https://www.covidzentrum.de",
         "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "(07) Covidzentrum Moabit",
+        "title": "Covidzentrum Moabit",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -135,7 +112,7 @@
         "telephone": null,
         "details_url": "https://www.covidzentrum.de",
         "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "(08) Covidzentrum Mitte",
+        "title": "Covidzentrum Mitte",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -158,7 +135,7 @@
         "telephone": null,
         "details_url": "https://www.covidzentrum.de",
         "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "(09) Covidzentrum Moritzplatz",
+        "title": "Covidzentrum Moritzplatz",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -240,29 +217,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.34331,
-          52.52941
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Stromstraße 21, 10551 Berlin",
-        "telephone": null,
-        "details_url": "https://corona-test-mitte.de",
-        "opening_hours": "Fr 08:00-19:45; Mo 08:00-19:45; Su 09:00-19:00; Tu 08:00-19:45; Sa 08:00-19:45; Th 08:00-19:45; We 08:00-19:45",
-        "title": "Corona Test Berlin Mitte",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.31691,
           52.50202
         ],
@@ -309,22 +263,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.31732,
-          52.61464
+          13.41473,
+          52.53939
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Berliner Str. 15, 13467 Berlin",
+        "location": "Knaackstraße 86, 10435 Berlin",
         "telephone": null,
-        "details_url": "https://Testzentrum-Hermsdorf.jimdosite.com",
-        "opening_hours": "Fr 10:00-18:00; Mo 10:00-18:00; Su 10:00-18:00; Tu 10:00-18:00; Sa 10:00-18:00; Th 10:00-18:00; We 10:00-18:00",
-        "title": "Corona-Teststelle Hermsdorf",
+        "details_url": "https://www.covid19center.de/prenzlauer-berg/?sku=covid19berlin",
+        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Tu 08:00-19:00; Sa 09:00-18:00; Th 08:00-19:00; We 08:00-19:00",
+        "title": "Deutsches Corona Testzentrum - Prenzlauer Berg",
         "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -425,29 +379,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.30366,
-          52.42673
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Lausanner Straße 83, 12205 Berlin",
-        "telephone": null,
-        "details_url": "https://www.apotheke-im-schweizer-viertel.de",
-        "opening_hours": "Fr 08:30-20:00; Mo 08:30-20:00; Tu 08:30-20:00; Sa 09:00-16:00; Th 08:30-20:00; We 08:30-20:00",
-        "title": "Apotheke im Schweizer Viertel",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.37913,
           52.529
         ],
@@ -541,6 +472,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.30366,
+          52.42673
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Lausanner Straße 83, 12205 Berlin",
+        "telephone": null,
+        "details_url": "https://www.apotheke-im-schweizer-viertel.de",
+        "opening_hours": "Fr 08:30-20:00; Mo 08:30-20:00; Tu 08:30-20:00; Sa 09:00-16:00; Th 08:30-20:00; We 08:30-20:00",
+        "title": "Apotheke im Schweizer Viertel",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.32551,
           52.50414
         ],
@@ -557,52 +511,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.28088,
-          52.47796
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Teplitzer Straße 38, 14193 Berlin",
-        "telephone": null,
-        "details_url": "https://www.covidtestcenter-berlin.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Covid Test Center Berlin Grunewald Schmagendorf",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.39524,
-          52.52887
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Torstraße 170, 10115 Berlin",
-        "telephone": null,
-        "details_url": "https://www.covidtestcenter-berlin.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Covid Test Center Berlin Mitte",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -656,30 +564,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.34556,
-          52.5068
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Budapester Straße 2, 10787 Berlin",
-        "telephone": null,
-        "details_url": "https://www.paramedic-berlin.de",
-        "opening_hours": null,
-        "title": "Paramedic Berlin",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.32898,
           52.44599
         ],
@@ -726,23 +610,24 @@
     {
       "geometry": {
         "coordinates": [
-          13.32232,
-          52.60665
+          13.34556,
+          52.5068
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Waidmannsluster Damm 182-194, 13469 Berlin",
+        "location": "Budapester Straße 2, 10787 Berlin",
         "telephone": null,
-        "details_url": "https://coronatest24.org/#",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Coronatest 24 Obi Reinickendorf",
+        "details_url": "https://www.paramedic-berlin.de",
+        "opening_hours": null,
+        "title": "Paramedic Berlin",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
+          "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
+          "Terminbuchung: nicht notwendig"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
       },
       "type": "Feature"
     },
@@ -763,29 +648,6 @@
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.4167,
-          52.51143
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Brückenstraße 1, 10179 Berlin",
-        "telephone": null,
-        "details_url": "https://www.123test-kitkat.club",
-        "opening_hours": "Fr 09:00-23:59; Su 00:00-03:00; Sa 12:00-23:59, 00:00-03:00",
-        "title": "123test KitKatClub",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
@@ -911,6 +773,52 @@
     {
       "geometry": {
         "coordinates": [
+          13.4167,
+          52.51143
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Brückenstraße 1, 10179 Berlin",
+        "telephone": null,
+        "details_url": "https://www.123test-kitkat.club",
+        "opening_hours": "Fr 12:00-18:00, 19:00-02:00; Mo 10:00-18:00; Tu 10:00-18:00; Sa 12:00-18:00, 19:00-02:00; Th 10:00-18:00; We 10:00-18:00",
+        "title": "123test KitKatClub",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.32177,
+          52.45807
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schloßstraße 10, 12163 Berlin",
+        "telephone": null,
+        "details_url": "https://www.covid19center.de/steglitz/?sku=covid19berlin",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-18:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Deutsches Corona Testzentrum - Steglitz",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.43436,
           52.48145
         ],
@@ -927,29 +835,6 @@
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.30826,
-          52.49642
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Brandenburgische Straße 23, 10707 Berlin",
-        "telephone": null,
-        "details_url": "https://berlin-testzentrum.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Mobiler Covid Testservice GBR",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -1073,6 +958,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.30826,
+          52.49642
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Brandenburgische Straße 23, 10707 Berlin",
+        "telephone": null,
+        "details_url": "https://berlin-testzentrum.de",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Mobiler Covid Testservice GBR",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.20456,
           52.53722
         ],
@@ -1089,29 +997,6 @@
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.31398,
-          52.50693
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Leibnizstraße 72, 10625 Berlin",
-        "telephone": null,
-        "details_url": "https://www.covid-testzentrum.de/charlottenburg",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-18:00; Tu 08:00-20:00; Sa 10:00-16:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Medicare Testzentrum",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -1165,6 +1050,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.31398,
+          52.50693
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Leibnizstraße 72, 10625 Berlin",
+        "telephone": null,
+        "details_url": "https://www.covid-testzentrum.de/charlottenburg",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-17:00; Tu 08:00-20:00; Sa 09:00-21:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Medicare Testzentrum Charlottenburg",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.32287,
           52.50897
         ],
@@ -1206,29 +1114,6 @@
           "Terminbuchung: notwendig"
         ],
         "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.15707,
-          52.53283
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Brunsbütteler Damm 263, 13591 Berlin",
-        "telephone": null,
-        "details_url": "https://www.apotheke-mumm.de",
-        "opening_hours": "Fr 12:00-14:00; Mo 12:00-14:00; We 12:00-14:00",
-        "title": "Mumm Apotheke",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
       },
       "type": "Feature"
     },
@@ -1374,6 +1259,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.15707,
+          52.53283
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Brunsbütteler Damm 263, 13591 Berlin",
+        "telephone": null,
+        "details_url": "https://www.apotheke-mumm.de",
+        "opening_hours": "Fr 12:00-14:00; Mo 12:00-14:00; We 12:00-14:00",
+        "title": "Mumm Apotheke",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.32598,
           52.46226
         ],
@@ -1411,6 +1319,29 @@
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.35565,
+          52.51943
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Joachim-Karnatz-Allee 47, 10557 Berlin",
+        "telephone": null,
+        "details_url": "https://www.coronatest-berlin.de",
+        "opening_hours": "Fr 08:30-15:30; Mo 08:30-15:30; Tu 08:30-15:30; Th 08:30-15:30; We 08:30-15:30",
+        "title": "Coronatest-Berlin",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
@@ -1489,30 +1420,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.38207,
-          52.41054
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Buckower Chaussee 100, 12277 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": null,
-        "title": "Ecocare Testzentrum Buckower Chaussee",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.36333,
           52.56554
         ],
@@ -1582,6 +1489,30 @@
     {
       "geometry": {
         "coordinates": [
+          13.38207,
+          52.41054
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Buckower Chaussee 100, 12277 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": null,
+        "title": "Ecocare Testzentrum Buckower Chaussee",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.37022,
           52.5424
         ],
@@ -1644,30 +1575,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3866242374991,
-          52.5312019144284
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Invalidenstraße 124, 10115 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": null,
-        "title": "Tenstzentrum Invalidenstraße",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ],
         "opening_hours_unclassified": "Keine Angabe"
       },
@@ -2000,52 +1907,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.28283,
-          52.58995
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Alt Tegel 2, 13507 Berlin",
-        "telephone": "+49 176 82136163",
-        "details_url": null,
-        "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 10:00-16:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
-        "title": "Testzentrum Primo Tegel",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.32865,
-          52.47301
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Friedrich-Wilhelm-Platz 16, 12161 Berlin",
-        "telephone": null,
-        "details_url": "https://www.schnelltest15.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "schnelltest15 Friedrich-Wilhelm-Platz",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.38553,
           52.46466
         ],
@@ -2176,6 +2037,52 @@
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.38428,
+          52.45877
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Tempelhofer Damm 198-200, 12103 Berlin",
+        "telephone": null,
+        "details_url": "https://www.tdammapotheke.de/website",
+        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Tu 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
+        "title": "Apotheke am T-Damm",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.28283,
+          52.58995
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Alt Tegel 2, 13507 Berlin",
+        "telephone": "+49 176 82136163",
+        "details_url": null,
+        "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 10:00-16:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
+        "title": "Testzentrum Primo Tegel",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
@@ -2464,22 +2371,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.35328,
-          52.59719
+          13.31432,
+          52.50621
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Wilhelmsruher Damm 142, 13439 Berlin",
+        "location": "Kantstraße 130B, 10625 Berlin",
         "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 12:00-18:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
-        "title": "Testzentrum Primo MV",
+        "details_url": "https://www.leibniz-apotheke.berlin/test",
+        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Tu 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
+        "title": "Leibniz Apotheke",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -2510,22 +2417,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.36339,
-          52.56585
+          13.35328,
+          52.59719
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Residenzstr. 106, 13407 Berlin",
-        "telephone": "+49176 72511193",
+        "location": "Wilhelmsruher Damm 142, 13439 Berlin",
+        "telephone": null,
         "details_url": null,
-        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Su 15:00-21:00; Tu 09:00-18:00; Sa 09:00-18:00; Th 09:00-18:00; We 09:00-18:00",
-        "title": "Resi-Testzentrum",
+        "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 12:00-18:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
+        "title": "Testzentrum Primo MV",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
+          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -2616,29 +2523,6 @@
         "title": "Testzentrum Alte Försterei",
         "hints": [
           "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.34689,
-          52.57434
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Lindauer Allee 49, 13407 Berlin",
-        "telephone": "+49176 21977748",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Tu 08:00-19:00; Sa 08:00-19:00; Th 08:00-19:00; We 08:00-19:00",
-        "title": "Teststation Lindauer",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
@@ -2810,29 +2694,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.37282,
-          52.50719
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Marlene-Dietrich-Platz 1, 10785 Berlin",
-        "telephone": null,
-        "details_url": "https://schnelltestberlin.de/potsdamerplatz",
-        "opening_hours": "Fr 07:00-03:00; Mo 07:00-03:00; Su 07:00-03:00; Tu 07:00-03:00; Sa 07:00-03:00; Th 07:00-03:00; We 07:00-03:00",
-        "title": "Schnelltestberlin.de | Potsdamerplatz",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.38281,
           52.55164
         ],
@@ -2902,40 +2763,17 @@
     {
       "geometry": {
         "coordinates": [
-          13.21804,
-          52.53753
+          13.37282,
+          52.50719
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Am Juliusturm 44, 13599 Berlin",
+        "location": "Marlene-Dietrich-Platz 1, 10785 Berlin",
         "telephone": null,
-        "details_url": "https://termin@schnelltest15.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "schnelltest15 Center Am Juliusturm",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.29282,
-          52.49138
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Caspar-Theyß-Straße 29, 14193 Berlin",
-        "telephone": null,
-        "details_url": "https://schnelltestberlin.de/martin-luther-krankenhaus",
-        "opening_hours": "Fr 06:00-18:00; Mo 06:00-18:00; Su 06:00-18:00; Tu 06:00-18:00; Sa 06:00-18:00; Th 06:00-18:00; We 06:00-18:00",
-        "title": "Schnelltest Berlin Martin-Luther-Krankenhaus",
+        "details_url": "https://schnelltestberlin.de/potsdamerplatz",
+        "opening_hours": "Fr 07:00-03:00; Mo 07:00-03:00; Su 07:00-03:00; Tu 07:00-03:00; Sa 07:00-03:00; Th 07:00-03:00; We 07:00-03:00",
+        "title": "Schnelltestberlin.de | Potsdamer Platz",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -3030,29 +2868,6 @@
         "title": "Ikea Schnelltest-Station Spandau",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.35427,
-          52.59704
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Wilhelmsruher Damm 140, 13439 Berlin",
-        "telephone": null,
-        "details_url": "https://schnelltestberlin.de",
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Schnelltest Berlin Märkisches Viertel",
-        "hints": [
-          "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
@@ -3455,29 +3270,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.33429,
-          52.5961
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Oranienburger Str. 88, 13437 Berlin",
-        "telephone": "+49173 7493544",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testung Wittenau",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.36692,
           52.54304
         ],
@@ -3510,13 +3302,13 @@
         "location": "Altonaer Straße 85, 13581 Berlin",
         "telephone": null,
         "details_url": "https://www.hbtr.eu",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 10:00-14:00; Tu 08:00-18:00; Sa 10:00-14:00; Th 08:00-18:00; We 08:00-18:00",
+        "opening_hours": "Fr 09:00-16:00; Mo 09:00-16:00; Tu 09:00-16:00; Th 09:00-16:00; We 09:00-16:00",
         "title": "Altonaer-Corona-Teststation",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -3756,6 +3548,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.2667421675316,
+          52.534737712108
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Wohlrabedamm 34, 13629 Berlin",
+        "telephone": "015214172247",
+        "details_url": "https://covid-testzentrum.net/berlin-siemensstadt",
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 10:00-18:00; Tu 08:00-18:00; Sa 10:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "Medicare Testzentrum Berlin Siemensstadt",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.54313,
           52.43587
         ],
@@ -3790,29 +3605,6 @@
         "details_url": "https://www.timecrew.de",
         "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Tu 07:00-20:00; Sa 08:00-20:00; Th 07:00-20:00; We 07:00-20:00",
         "title": "Teststation Berlin-Weißensee bei Hornbach",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.42462,
-          52.48715
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Hermannplatz, 10967 Berlin",
-        "telephone": null,
-        "details_url": "https://www.testzentrum-berlin.com",
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Teststation UBHF Hermannplatz",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -3862,6 +3654,29 @@
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.25959,
+          52.43319
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Teltower Damm 19, 14169 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Tu 09:00-18:00; Sa 09:30-15:30; Th 09:00-18:00; We 09:00-18:00",
+        "title": "Zehlendorf Apotheke Testzentrum",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
@@ -3927,7 +3742,7 @@
         "telephone": null,
         "details_url": "https://www.mycoronatest.berlin",
         "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 07:00-18:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
-        "title": "(684) myCoronatest Potsdamer Str.",
+        "title": "myCoronatest Potsdamer Str.",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -4103,29 +3918,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.15573,
-          52.53306
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Brunsbütteler Damm 274, 13591 Berlin",
-        "telephone": null,
-        "details_url": "https://testedichschnell.de/berlin-brunsbuetteler-damm",
-        "opening_hours": "Fr 10:00-18:00; Mo 10:00-18:00; Tu 10:00-18:00; Sa 10:00-18:00; Th 10:00-18:00; We 10:00-18:00",
-        "title": "Corona-schnellteststation REWE Brunsbütteler Damm",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.36108,
           52.49499
         ],
@@ -4172,6 +3964,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.15573,
+          52.53306
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Brunsbütteler Damm 274, 13591 Berlin",
+        "telephone": null,
+        "details_url": "https://testedichschnell.de/berlin-brunsbuetteler-damm",
+        "opening_hours": "Fr 10:00-18:00; Mo 10:00-18:00; Tu 10:00-18:00; Sa 10:00-18:00; Th 10:00-18:00; We 10:00-18:00",
+        "title": "Corona-schnellteststation REWE Brunsbütteler Damm",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.28182,
           52.5873
         ],
@@ -4195,29 +4010,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.31512,
-          52.57744
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Eichborndamm 97, 13403 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testzentrum Reinickendorf",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.50759,
           52.45747
         ],
@@ -4234,30 +4026,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.43255,
-          52.46747
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Hermannstraße 158a, 12051 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": null,
-        "title": "Teststation am Hermann Quartier",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ],
         "opening_hours_unclassified": "Keine Angabe"
       },
@@ -4439,29 +4207,6 @@
         "details_url": "https://stz-berlin.de",
         "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
         "title": "STZ-Berlin Wilhelmsruher Damm",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.27807,
-          52.48783
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Bismarckallee 23, 14193 Berlin",
-        "telephone": null,
-        "details_url": "https://testcenter-corona.de",
-        "opening_hours": "Fr 10:00-18:00; Mo 08:00-16:00; Su 10:00-16:00; Tu 08:00-16:00; Sa 10:00-18:00; Th 08:00-16:00; We 08:00-16:00",
-        "title": "Testcenter Corona Johannisches Sozialwerk e.V.",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
@@ -4682,6 +4427,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.41709,
+          52.54692
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Stargarder Straße 74, 10437 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-21:00; Mo 08:00-20:00; Su 11:00-20:00; Tu 08:00-20:00; Sa 08:00-21:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Stargarder Teststation",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.33388,
           52.5269
         ],
@@ -4693,29 +4461,6 @@
         "details_url": "https://www.moabit-testzentrum.de",
         "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 08:00-20:00; Tu 07:00-22:00; Sa 08:00-20:00; Th 07:00-22:00; We 07:00-22:00",
         "title": "Corona Schnelltestzentrum Berlin Moabit",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.57599,
-          52.45434
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Bahnhofstraße 5, 12555 Berlin",
-        "telephone": "+491716444431",
-        "details_url": "https://pyrothron.com",
-        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Tu 09:00-18:00; Sa 09:00-13:00; Th 09:00-18:00; We 09:00-18:00",
-        "title": "Corona Teststation Thron Pyro GmbH",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
@@ -4912,6 +4657,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.49712,
+          52.41643
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Alt-Rudow 72-74, 12355 Berlin",
+        "telephone": null,
+        "details_url": "https://testen.berlin/purus-curae",
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "Corona Teststation Alt-Rudow",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.50229,
           52.51008
         ],
@@ -5005,29 +4773,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.30691,
-          52.50587
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Wilmersdorfer Straße 108, 10627 Berlin",
-        "telephone": null,
-        "details_url": "https://www.schnelltest-in-berlin.de",
-        "opening_hours": "Fr 08:00-22:00; Mo 08:00-22:00; Su 08:00-22:00; Tu 08:00-22:00; Sa 08:00-22:00; Th 08:00-22:00; We 08:00-22:00",
-        "title": "Schnelltest Station - Charlottenburg bei Media Markt",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.31085,
           52.52576
         ],
@@ -5075,6 +4820,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.30691,
+          52.50587
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Wilmersdorfer Straße 108, 10627 Berlin",
+        "telephone": null,
+        "details_url": "https://www.schnelltest-in-berlin.de",
+        "opening_hours": "Fr 08:00-22:00; Mo 08:00-22:00; Su 08:00-22:00; Tu 08:00-22:00; Sa 08:00-22:00; Th 08:00-22:00; We 08:00-22:00",
+        "title": "Schnelltest Station - Charlottenburg bei Media Markt",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.19516,
           52.5213
         ],
@@ -5093,29 +4861,6 @@
           "Terminbuchung: optional"
         ],
         "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.38289,
-          52.55408
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Prinzenallee 81, 13357 Berlin",
-        "telephone": "+493084514024",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Testzentrum - Prinzenallee",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
       },
       "type": "Feature"
     },
@@ -5246,15 +4991,14 @@
         "location": "Kurfürstenstraße 153, 10785 Berlin",
         "telephone": null,
         "details_url": null,
-        "opening_hours": null,
+        "opening_hours": "Fr 10:00-18:00; Mo 10:00-18:00; Su 10:00-15:00; Tu 10:00-18:00; Sa 10:00-18:00; Th 10:00-18:00; We 10:00-18:00",
         "title": "Testzentrum Kurfürstenstraße",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
+        ]
       },
       "type": "Feature"
     },
@@ -5585,24 +5329,23 @@
     {
       "geometry": {
         "coordinates": [
-          13.27538,
-          52.43966
+          13.40643,
+          52.40163
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Berliner Straße 67, 14169 Berlin",
-        "telephone": null,
-        "details_url": "https://smarttest-berlin.de",
-        "opening_hours": null,
-        "title": "Smarttest67",
+        "location": "Lichtenrader Damm 131, 12305 Berlin",
+        "telephone": "+491734659327",
+        "details_url": "https://www.greentestcorona.de",
+        "opening_hours": "Fr 07:00-16:00; Mo 07:00-16:00; Su 07:00-16:00; Tu 07:00-16:00; Sa 07:00-16:00; Th 07:00-16:00; We 07:00-16:00",
+        "title": "Covid Testzentrum Green, Lichtenrader Damm 131",
         "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
+          "Terminbuchung: optional"
+        ]
       },
       "type": "Feature"
     },
@@ -5679,30 +5422,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.31569,
-          52.54746
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Leopoldplatz 1, 13353 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": null,
-        "title": "TestTreff",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.33603,
           52.59575
         ],
@@ -5720,6 +5439,30 @@
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
         ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3576972,
+          52.5475193
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Leopoldplatz 1, 13353 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": null,
+        "title": "TestTreff",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
       },
       "type": "Feature"
     },
@@ -5864,29 +5607,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.45755,
-          52.46633
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Grenzallee 22, 12057 Berlin",
-        "telephone": null,
-        "details_url": "https://www.testzentrum-berlin.com",
-        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Tu 07:00-19:00; Th 07:00-19:00; We 07:00-19:00",
-        "title": "Grenzallee walk and go Teststation",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.36009,
           52.50011
         ],
@@ -6018,29 +5738,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.29529,
-          52.49821
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Kurfürstendamm 105, 10711 Berlin",
-        "telephone": null,
-        "details_url": "https://wetest-germany.de/eiffel/eiffel",
-        "opening_hours": "Fr 08:30-20:00; Mo 08:30-20:00; Su 08:30-20:00; Tu 08:30-20:00; Sa 08:30-20:00; Th 08:30-20:00; We 08:30-20:00",
-        "title": "WeTest Germany - Eiffel",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -6281,29 +5978,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.4028,
-          52.52899
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Linienstraße 71, 10119 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Su 10:00-21:00; Tu 07:00-21:00; Sa 10:00-21:00; Th 07:00-21:00; We 07:00-21:00",
-        "title": "AM Corona Testzentrum Linienstraße",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.18997,
           52.53636
         ],
@@ -6365,6 +6039,52 @@
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4028,
+          52.52899
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Linienstraße 71, 10119 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Su 10:00-21:00; Tu 07:00-21:00; Sa 10:00-21:00; Th 07:00-21:00; We 07:00-21:00",
+        "title": "AM Corona Testzentrum Linienstraße",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.53213,
+          52.45212
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schnellerstraße 81, 12439 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Testzentrum Schnellerstr. 81",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
         ]
@@ -6514,30 +6234,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.2988,
-          52.5308
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Max-Dohrn-Straße 8, 10589 Berlin",
-        "telephone": null,
-        "details_url": "https://schnelltest15.de",
-        "opening_hours": null,
-        "title": "schnelltest 15 Mobil",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.37696,
           52.40717
         ],
@@ -6631,29 +6327,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.41387,
-          52.52186
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Alexanderplatz 8, 10178 Berlin",
-        "telephone": null,
-        "details_url": "https://www.testzentrumroyal.de",
-        "opening_hours": "Fr 08:00-23:00; Mo 08:00-21:00; Su 08:00-21:00; Tu 08:00-21:00; Sa 08:00-23:00; Th 08:00-21:00; We 08:00-21:00",
-        "title": "Testzentrum Alexanderplatz",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.43212,
           52.46612
         ],
@@ -6724,6 +6397,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.45889,
+          52.50843
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Simplonstraße 21, 10245 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "Corona Teststation Berlin",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.43006,
           52.53276
         ],
@@ -6747,22 +6443,45 @@
     {
       "geometry": {
         "coordinates": [
-          13.45889,
-          52.50843
+          13.38724,
+          52.49231
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Simplonstraße 21, 10245 Berlin",
+        "location": "Mehringdamm 44, 10961 Berlin",
         "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
-        "title": "Corona Teststation Berlin",
+        "details_url": "https://covidtest-sindbad.jimdosite.com/meine-leistungen",
+        "opening_hours": "Fr 10:00-21:00; Mo 10:00-18:00; Su 10:00-18:00; Tu 10:00-18:00; Sa 10:00-21:00; Th 10:00-18:00; We 10:00-18:00",
+        "title": "CovidTest-Sindbad",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.41387,
+          52.52186
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Alexanderplatz 8, 10178 Berlin",
+        "telephone": null,
+        "details_url": "https://www.testzentrumroyal.de",
+        "opening_hours": "Fr 08:00-23:00; Mo 08:00-21:00; Su 08:00-21:00; Tu 08:00-21:00; Sa 08:00-23:00; Th 08:00-21:00; We 08:00-21:00",
+        "title": "Testzentrum Alexanderplatz",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -6839,29 +6558,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.46564,
-          52.50952
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Glatzer Straße 7, 10247 Berlin",
-        "telephone": null,
-        "details_url": "https://www.greentestcorona.de",
-        "opening_hours": "Fr 07:00-17:00; Mo 07:00-17:00; Su 07:00-17:00; Tu 07:00-17:00; Sa 07:00-17:00; Th 07:00-17:00; We 07:00-17:00",
-        "title": "Covid Testzentrum Green, Glatzerstr.7",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.5988,
           52.40749
         ],
@@ -6896,6 +6592,29 @@
         "details_url": null,
         "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Su 07:00-21:00; Tu 07:00-21:00; Sa 07:00-21:00; Th 07:00-21:00; We 07:00-21:00",
         "title": "Dein Schnelltestzentrum Berlin - Mokum",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.46564,
+          52.50952
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Glatzer Straße 7, 10247 Berlin",
+        "telephone": null,
+        "details_url": "https://www.greentestcorona.de",
+        "opening_hours": "Fr 08:00-02:00; Mo 07:00-19:45; Su 08:00-19:45; Tu 07:00-19:45; Sa 08:00-02:00; Th 07:00-19:45; We 07:00-19:45",
+        "title": "Covid Testzentrum Green, Glatzerstr.7",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
@@ -7000,24 +6719,23 @@
     {
       "geometry": {
         "coordinates": [
-          13.3287,
-          52.52788
+          13.40297,
+          52.56558
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Beusselstraße 16, 10553 Berlin",
+        "location": "Florastraße 24, 13187 Berlin",
         "telephone": null,
-        "details_url": "https://www.alisali.de",
-        "opening_hours": null,
-        "title": "Sali Beusselstraße",
+        "details_url": "https://testcenter-corona.de",
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 09:00-18:00; Tu 08:00-18:00; Sa 09:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "Testcenter Corona Florastraße",
         "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
+        ]
       },
       "type": "Feature"
     },
@@ -7093,24 +6811,46 @@
     {
       "geometry": {
         "coordinates": [
-          13.33886,
-          52.52556
+          13.63491,
+          52.39543
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Alt-Moabit 83c, 10555 Berlin",
-        "telephone": null,
-        "details_url": "https://www.aktivtel.de",
-        "opening_hours": null,
-        "title": "Krasimir",
+        "location": "Rohrwallallee 11, 12527 Berlin",
+        "telephone": "+49306743458",
+        "details_url": "https://www.sscbg.de",
+        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Tu 07:00-19:00; Th 07:00-19:00; We 07:00-19:00",
+        "title": "SSCBG Bürger Test Station",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.25891,
+          52.54499
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Buolstraße 14, 13629 Berlin",
+        "telephone": null,
+        "details_url": "https://www.greentestcorona.de",
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "Covid testzentrum Green, Buolstr. 14",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
+        ]
       },
       "type": "Feature"
     },
@@ -7211,6 +6951,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.36429,
+          52.56327
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Markstraße 4, 13409 Berlin",
+        "telephone": "+4915255150050",
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Corona-Schnellstest Markstraße 4",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.37911,
           52.55077
         ],
@@ -7243,39 +7006,14 @@
         "location": "Hermannstraße 56, 12049 Berlin",
         "telephone": null,
         "details_url": "https://www.hztestzentrum.de",
-        "opening_hours": null,
+        "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 08:00-22:00; Tu 07:00-22:00; Sa 08:00-22:00; Th 07:00-22:00; We 07:00-22:00",
         "title": "HZ Testzentrum",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.34777,
-          52.48145
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Hauptstraße 52, 10827 Berlin",
-        "telephone": null,
-        "details_url": "https://friseur.de",
-        "opening_hours": null,
-        "title": "Ahmad Friseur",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
+        ]
       },
       "type": "Feature"
     },
@@ -7338,7 +7076,7 @@
         "location": "Eichborndamm 236, 13437 Berlin",
         "telephone": null,
         "details_url": "https://www.smarttest-berlin.de",
-        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Su 09:00-13:00; Tu 09:00-18:00; Sa 09:00-18:00; Th 09:00-18:00; We 09:00-18:00",
+        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Su 09:00-18:00; Tu 09:00-18:00; Sa 09:00-18:00; Th 09:00-18:00; We 09:00-18:00",
         "title": "Testzentrum am Reinickendorfer Park",
         "hints": [
           "PCR-Nachtestung: ja",
@@ -7346,6 +7084,30 @@
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.34777,
+          52.48145
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Hauptstraße 52, 10827 Berlin",
+        "telephone": null,
+        "details_url": "https://friseur.de",
+        "opening_hours": null,
+        "title": "Ahmad Friseur",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
       },
       "type": "Feature"
     },
@@ -7412,52 +7174,6 @@
         "title": "Cerebra Coffee Teststation",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.35642,
-          52.48635
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Hauptstraße 21, 10827 Berlin",
-        "telephone": "+491632997118",
-        "details_url": "https://www.alisali.de",
-        "opening_hours": "Fr 09:00-04:00; Mo 09:00-04:00; Su 09:00-04:00; Tu 09:00-04:00; Sa 09:00-04:00; Th 09:00-04:00; We 09:00-04:00",
-        "title": "Hauptstraße21",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.38069,
-          52.53246
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Chausseestraße 31, 10115 Berlin",
-        "telephone": null,
-        "details_url": "https://www.testzentrum-berlin.com",
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Chausseestraße walk and go Teststation",
-        "hints": [
-          "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
@@ -7752,30 +7468,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.4411965656584,
-          52.5568342131179
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Bühringstraße 2-8, 13086 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": null,
-        "title": "Workforce and Care Böhringstraße",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.4596400683361,
           52.5262347555
         ],
@@ -7786,7 +7478,7 @@
         "telephone": null,
         "details_url": null,
         "opening_hours": null,
-        "title": "Workforce and Care Max-Brunnow-Straße",
+        "title": "Corona Border Point",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -7810,7 +7502,7 @@
         "telephone": null,
         "details_url": null,
         "opening_hours": null,
-        "title": "Workforce and Care Mühlenstraße",
+        "title": "Corona Border Point",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -7834,7 +7526,7 @@
         "telephone": null,
         "details_url": null,
         "opening_hours": null,
-        "title": "Workforce and Care Pichelserderstraße",
+        "title": "Corona Border Point",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -7967,30 +7659,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3905,
-          52.5069
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Friedrichstraße 43-45, 10117 Berlin",
-        "telephone": null,
-        "details_url": "https://www.deinecoronatester.de",
-        "opening_hours": null,
-        "title": "Deine Coronatester Checkpoint Charlie",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.49966852753,
           52.5526660869591
         ],
@@ -8001,7 +7669,7 @@
         "telephone": null,
         "details_url": null,
         "opening_hours": null,
-        "title": "Workforce and Care Degnerstraße",
+        "title": "Corona Border Point",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -8029,54 +7697,6 @@
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2456,
-          52.5786
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Schwarzer Weg 95, 13505 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": null,
-        "title": "Strandbad Tegelsee",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.33247,
-          52.52704
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Turmstraße 49, 10551 Berlin",
-        "telephone": null,
-        "details_url": "https://www.alisali.de",
-        "opening_hours": null,
-        "title": "Turmstraße49",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ],
@@ -8127,30 +7747,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.28303,
-          52.59055
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Berliner Straße 105, 13507 Berlin",
-        "telephone": null,
-        "details_url": "https://www.aktivtel.de",
-        "opening_hours": null,
-        "title": "Berinerstr105",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ],
         "opening_hours_unclassified": "Keine Angabe"
       },
@@ -8302,30 +7898,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.42541,
-          52.47956
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Hermannstraße 41, 12049 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": null,
-        "title": "Best Smile Corona Test Station",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.42514,
           52.47745
         ],
@@ -8420,30 +7992,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.22909,
-          52.62553
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Ruppiner Chaussee 405, 13503 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": null,
-        "title": "RuppinerChaussee405",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.48025,
           52.51621
         ],
@@ -8468,6 +8016,53 @@
     {
       "geometry": {
         "coordinates": [
+          13.41204,
+          52.53111
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schönhauser Allee 12, 10119 Berlin",
+        "telephone": null,
+        "details_url": "https://schnelltestberlin.de/senefelderplatz",
+        "opening_hours": null,
+        "title": "Schnelltestberlin.de | Senefelderplatz",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3892391558865,
+          52.4364163763858
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Mariendorfer Damm 173, 12107 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Su 10:00-14:00; Tu 09:00-18:00; Sa 09:00-18:00; Th 09:00-18:00; We 09:00-18:00",
+        "title": "CoronaTest 24 bei MaVie",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.43274,
           52.48483
         ],
@@ -8484,53 +8079,6 @@
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.47069,
-          52.50642
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Neue Bahnhofstraße 7B, 10245 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 20:00-00:00; Tu 18:00-22:00; Sa 20:00-00:00; Th 18:00-22:00; We 18:00-22:00",
-        "title": "Test & Bier",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.35306,
-          52.5499
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Müllerstraße 40, 13353 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": null,
-        "title": "müller Corona Testzentrum",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ],
         "opening_hours_unclassified": "Keine Angabe"
       },
@@ -8601,52 +8149,6 @@
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.44447,
-          52.46799
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "mobil, mobil mobil",
-        "telephone": "0176/72205552",
-        "details_url": "https://wirtesten.online/purus-curae-mobil1",
-        "opening_hours": "Fr 08:00-23:00; Mo 08:00-23:00; Su 08:00-23:00; Tu 08:00-23:00; Sa 08:00-23:00; Th 08:00-23:00; We 08:00-23:00",
-        "title": "Corona Teststation Purus Curae Mobil1",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.4611,
-          52.43121
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Fritz-Erler-Allee 61, 12351 Berlin",
-        "telephone": null,
-        "details_url": "https://www.resinbyangiee.de",
-        "opening_hours": "Fr 09:00-23:00; Mo 09:00-23:00; Su 09:00-23:00; Tu 09:00-23:00; Sa 09:00-23:00; Th 09:00-23:00; We 09:00-23:00",
-        "title": "Corona Teststation Immelmann",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
           "Terminbuchung: nicht notwendig"
         ]
       },
@@ -8772,29 +8274,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.48989,
-          52.52658
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Herzbergstraße 30-32, 10365 Berlin",
-        "telephone": "01743857082",
-        "details_url": null,
-        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Su 09:00-20:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
-        "title": "HerzbergTestZentrum",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.48857,
           52.51238
         ],
@@ -8818,22 +8297,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.43516,
-          52.48037
+          13.48989,
+          52.52658
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Neckarstraße 2, 12053 Berlin",
-        "telephone": null,
-        "details_url": "https://testzentrum-th-de.jimdofree.com/kontakt",
-        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Su 10:00-18:00; Tu 09:00-19:00; Sa 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
-        "title": "Testzentrum Thüringer Hof",
+        "location": "Herzbergstraße 30-32, 10365 Berlin",
+        "telephone": "01743857082",
+        "details_url": null,
+        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Su 09:00-20:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
+        "title": "HerzbergTestZentrum",
         "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
           "Tests für Kinder: ja",
-          "Terminbuchung: optional"
+          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -8911,29 +8390,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.24151,
-          52.5386
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Nonnendammallee 30, 13599 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Tu 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Nonnendammallee mobile Teststelle to-go",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.52379,
           52.46124
         ],
@@ -8996,6 +8452,29 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: ja",
           "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.43516,
+          52.48037
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Neckarstraße 2, 12053 Berlin",
+        "telephone": null,
+        "details_url": "https://testzentrum-th-de.jimdofree.com/kontakt",
+        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Su 10:00-18:00; Tu 09:00-19:00; Sa 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
+        "title": "Testzentrum Thüringer Hof",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -9073,75 +8552,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.15463,
-          52.54956
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Hauskavelweg 19, 13589 Berlin",
-        "telephone": "+4917678513700",
-        "details_url": "https://mobilestestzelt-covidtest-berlin.com",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Mobiles Testzelt",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.57259,
-          52.41427
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Adlergestell 543, 12527 Berlin",
-        "telephone": null,
-        "details_url": "https://www.schnelltests-berlin.com",
-        "opening_hours": "Fr 10:00-19:00; Mo 10:00-19:00; Su 10:00-19:00; Tu 10:00-19:00; Sa 10:00-19:00; Th 10:00-19:00; We 10:00-19:00",
-        "title": "BG Total Grünau",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.63114,
-          52.38724
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Adlergestell 625, 12527 Berlin",
-        "telephone": null,
-        "details_url": "https://www.schnelltests-berlin.com",
-        "opening_hours": "Fr 10:00-18:00; Mo 10:00-18:00; Su 10:00-18:00; Tu 10:00-18:00; Sa 10:00-18:00; Th 10:00-18:00; We 10:00-18:00",
-        "title": "BG Total Schmöckwitz",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.57283,
           52.41242
         ],
@@ -9158,29 +8568,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: ja",
           "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.16243,
-          52.52188
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Magistratsweg 13, 13593 Berlin",
-        "telephone": null,
-        "details_url": "https://www.bbtest.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "BB Test",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -9269,7 +8656,7 @@
         "opening_hours": "Fr 08:00-19:00; Mo 08:00-18:00; Tu 08:00-18:00; Sa 10:00-19:00; Th 08:00-18:00; We 08:00-18:00",
         "title": "10117 Testzentrum Gendarmenmarkt",
         "hints": [
-          "PCR-Nachtestung: ja",
+          "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
@@ -9280,19 +8667,19 @@
     {
       "geometry": {
         "coordinates": [
-          13.38847,
-          52.52873
+          13.16243,
+          52.52188
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Novalisstraße 11, 10115 Berlin",
+        "location": "Magistratsweg 13, 13593 Berlin",
         "telephone": null,
-        "details_url": "https://www.stadtapotheke-berlin.de",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Tu 08:00-18:00; Sa 09:00-17:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "10115 Teststelle -Novalisstraße",
+        "details_url": "https://www.bbtest.de",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "BB Test",
         "hints": [
-          "PCR-Nachtestung: ja",
+          "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
@@ -9372,29 +8759,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.40273,
-          52.52797
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Rosenthaler Straße 9, 10119 Berlin",
-        "telephone": null,
-        "details_url": "https://www.stadtapotheke-berlin.de",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Tu 08:00-18:00; Sa 10:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "10119 Teststelle Rosenthaler Platz",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.42947,
           52.5022
         ],
@@ -9411,6 +8775,29 @@
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3884502388451,
+          52.5207654003763
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Friedrichstraße 101, 10117 Berlin",
+        "telephone": null,
+        "details_url": "https://www.coronatest.de",
+        "opening_hours": "Fr 06:00-20:00; Mo 06:00-20:00; Su 06:00-20:00; Tu 06:00-20:00; Sa 06:00-20:00; Th 06:00-20:00; We 06:00-20:00",
+        "title": "10117 Coronatest.de S/U Friedrichstraße",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -9524,29 +8911,6 @@
         "title": "10969 Coronazentrum U-Bhf. Kochstraße",
         "hints": [
           "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.38002,
-          52.47826
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Erika-Gräfin-von-Brockdorff-Platz, 12101 Berlin",
-        "telephone": null,
-        "details_url": "https://coronatest.de",
-        "opening_hours": "Fr 06:00-20:00; Mo 06:00-20:00; Su 10:00-18:00; Tu 06:00-20:00; Sa 10:00-18:00; Th 06:00-20:00; We 06:00-20:00",
-        "title": "12101 Coronatest.de S/U Südkreuz",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
@@ -9927,30 +9291,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.40865,
-          52.54727
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Gleimstraße 17, 10437 Berlin",
-        "telephone": null,
-        "details_url": "https://am-corona-testzentrum.covidservicepoint.de",
-        "opening_hours": null,
-        "title": "AM Corona Testzentrum",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.41323,
           52.50295
         ],
@@ -10020,6 +9360,30 @@
     {
       "geometry": {
         "coordinates": [
+          13.40865,
+          52.54727
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Gleimstraße 17, 10437 Berlin",
+        "telephone": null,
+        "details_url": "https://am-corona-testzentrum.covidservicepoint.de",
+        "opening_hours": null,
+        "title": "AM Corona Testzentrum",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.42838,
           52.48458
         ],
@@ -10060,30 +9424,6 @@
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.41395,
-          52.55165
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Schönhauser Allee 108, 10439 Berlin",
-        "telephone": null,
-        "details_url": "https://www.aprtestzentrum.de",
-        "opening_hours": null,
-        "title": "APR Testzentrum",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
       },
       "type": "Feature"
     },
@@ -10275,29 +9615,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3599264,
-          52.4901879
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Großbeerenstr. 2-10, 12107 Berlin",
-        "telephone": "017662707061",
-        "details_url": "https://www.schnelltests-berlin.com",
-        "opening_hours": "Fr 11:00-20:00; Mo 11:00-20:00; Su 11:00-20:00; Tu 11:00-20:00; Sa 11:00-20:00; Th 11:00-20:00; We 11:00-20:00",
-        "title": "BG Südbloc",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.43648,
           52.5347
         ],
@@ -10367,29 +9684,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.4226,
-          52.49066
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Boppstraße 9, 10967 Berlin",
-        "telephone": "+4915774210003",
-        "details_url": "https://www.t-wint-facility.de",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "BTZ Schnelltest Zentrum",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.43204,
           52.50185
         ],
@@ -10406,29 +9700,6 @@
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.20506,
-          52.5359
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Charlottenstraße 27, 13597 Berlin",
-        "telephone": "015751477373",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-19:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "BTS Schnelltest Zentrum",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -10505,53 +9776,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.39971,
-          52.49965
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Neuenburger Straße 19, 10969 Berlin",
-        "telephone": null,
-        "details_url": "https://www.checkpoint-schnelltest.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Checkpoint Schnelltest",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3420717556944,
-          52.4869422444076
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Salzburger Straße 19, 10825 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": null,
-        "title": "WeTest Germany - Tomasa Schöneberg",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.361,
           52.526995
         ],
@@ -10575,22 +9799,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.37903,
-          52.55241
+          13.20506,
+          52.5359
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Buttmannstraße 19, 13357 Berlin",
-        "telephone": null,
-        "details_url": "https://checkpoint-schnelltest.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Checkpoint Schnelltest Wedding 2",
+        "location": "Charlottenstraße 27, 13597 Berlin",
+        "telephone": "015751477373",
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-19:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "BTS Schnelltest Zentrum",
         "hints": [
-          "PCR-Nachtestung: keine Angabe",
+          "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -10598,22 +9822,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.3217,
-          52.48149
+          13.4226,
+          52.49066
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Koblenzer Straße 1, 10715 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Checkpoint Schnelltest Charlottenburg",
+        "location": "Boppstraße 9, 10967 Berlin",
+        "telephone": "+4915774210003",
+        "details_url": "https://www.t-wint-facility.de",
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "BTZ Schnelltest Zentrum",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -10637,6 +9861,29 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.41367,
+          52.55008
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schönhauser Allee 115, 10439 Berlin",
+        "telephone": null,
+        "details_url": "https://www.corona-check-up.de",
+        "opening_hours": "Fr 10:00-18:00; Mo 10:00-18:00; Su 10:00-18:00; Tu 10:00-18:00; Sa 10:00-18:00; Th 10:00-18:00; We 10:00-18:00",
+        "title": "Corona Checkup Schönhauser Allee 115",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -10839,6 +10086,29 @@
         "details_url": "https://coronatest24.org/#",
         "opening_hours": "Fr 09:00-19:00; Su 10:00-16:00; Tu 09:00-19:00; Sa 10:00-18:00; Th 09:00-19:00; We 09:00-19:00",
         "title": "Coronatest 24 Pankow",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3445,
+          52.5315
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Birkenstraße 22, 10559 Berlin",
+        "telephone": null,
+        "details_url": "http://corona-test-mitte.de",
+        "opening_hours": "Fr 08:30-19:30; Mo 08:30-19:30; Su 09:00-19:00; Tu 08:30-19:30; Sa 08:30-19:30; Th 08:30-19:30; We 08:30-19:30",
+        "title": "Corona Test Berlin Mitte im MOA Bogen",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
@@ -11151,23 +10421,24 @@
     {
       "geometry": {
         "coordinates": [
-          13.4645,
-          52.5151
+          13.4570815,
+          52.5112065
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Samariterstraße 40, 10247 Berlin",
+        "location": "Simon-Dach-Straße 40, 10245 Berlin",
         "telephone": null,
-        "details_url": "https://www.covid19center.de/samariterstrasse",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Corona Testzentrum Samariterstraße",
+        "details_url": null,
+        "opening_hours": null,
+        "title": "Deutsches Corona Testzentrum - Friedrichshain",
         "hints": [
-          "PCR-Nachtestung: ja",
+          "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: ja",
+          "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ]
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
       },
       "type": "Feature"
     },
@@ -11237,6 +10508,29 @@
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.42125,
+          52.49438
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Kottbusser Damm 97, 10967 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Tu 09:00-19:00; Sa 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
+        "title": "Corona Zentrum HT",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -11329,75 +10623,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.32193,
-          52.50258
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Knesebeckstraße 35, 10623 Berlin",
-        "telephone": null,
-        "details_url": "https://www.covidtestcenter-berlin.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Covid Test Center Berlin Charlottenburg",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.33035,
-          52.50364
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Kurfürstendamm 22, 10719 Berlin",
-        "telephone": null,
-        "details_url": "https://www.covidtestcenter-berlin.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Covid Test Center Berlin Kranzler Eck",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.42951,
-          52.49578
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Reichenberger Straße 61, 10999 Berlin",
-        "telephone": null,
-        "details_url": "https://www.covidtestcenter-berlin.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Covid Test Center Berlin Reichenberger Str.",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -11520,6 +10745,75 @@
     {
       "geometry": {
         "coordinates": [
+          13.35818,
+          52.48696
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Crellestraße 2, 10827 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-21:00; Mo 08:00-21:00; Su 08:00-21:00; Tu 08:00-21:00; Sa 08:00-21:00; Th 08:00-21:00; We 08:00-21:00",
+        "title": "COVID - Test to go Prinz",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.40419,
+          52.56969
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Breite Straße 20, 13187 Berlin",
+        "telephone": null,
+        "details_url": "https://www.covid19center.de",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Deutsches Corona Testzentrum - Pankow",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.57918,
+          52.45838
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Bahnhofstraße 33-38, 12555 Berlin",
+        "telephone": null,
+        "details_url": "https://www.covid19center.de/koepenick",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Deutsches Corona Testzentrum - Köpenick",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.26122,
           52.43652
         ],
@@ -11622,7 +10916,7 @@
         "telephone": null,
         "details_url": "https://www.dhi24.de",
         "opening_hours": "Fr 10:00-18:00; Mo 10:00-18:00; Tu 10:00-18:00; Sa 10:00-14:00; Th 10:00-18:00; We 10:00-14:00",
-        "title": "(10) Deutsche Hygiene- und Infektionsschutz GbR",
+        "title": "Deutsche Hygiene- und Infektionsschutz GbR",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -11694,29 +10988,6 @@
         "title": "Futura",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.30721,
-          52.50101
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Wilmersdorfer Straße 92-93, 10629 Berlin",
-        "telephone": null,
-        "details_url": "https://www.fastandsafe-medicare.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Fast & Safe Wilmersdorferstr.",
-        "hints": [
-          "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
@@ -12235,30 +11506,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.39806,
-          52.49143
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Schleiermacherstraße 18, 10961 Berlin",
-        "telephone": null,
-        "details_url": "https://guinchithesculptor.wixsite.com/pandora-berlin",
-        "opening_hours": null,
-        "title": "Pandora",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.41133,
           52.55076
         ],
@@ -12375,6 +11622,30 @@
     {
       "geometry": {
         "coordinates": [
+          13.39806,
+          52.49143
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schleiermacherstraße 18, 10961 Berlin",
+        "telephone": null,
+        "details_url": "https://guinchithesculptor.wixsite.com/pandora-berlin",
+        "opening_hours": null,
+        "title": "Pandora",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.4094551400371,
           52.5057791982806
         ],
@@ -12385,7 +11656,7 @@
         "telephone": null,
         "details_url": null,
         "opening_hours": null,
-        "title": "Workforce and Care Stallschreiberstraße",
+        "title": "Corona Border Point",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -12399,21 +11670,21 @@
     {
       "geometry": {
         "coordinates": [
-          13.35343,
-          52.59905
+          13.33119,
+          52.50297
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Straupitzer Steig, 13439 Berlin",
-        "telephone": "017662465779",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Ready-To-Test",
+        "location": "Joachimsthaler Straße 10-12, 10719 Berlin",
+        "telephone": null,
+        "details_url": "https://www.oms-teststation.de",
+        "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 07:00-22:00; Tu 07:00-22:00; Sa 07:00-22:00; Th 07:00-22:00; We 07:00-22:00",
+        "title": "O.M.S. - Teststation",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
+          "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
         ]
       },
@@ -12537,6 +11808,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.35343,
+          52.59905
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Straupitzer Steig, 13439 Berlin",
+        "telephone": "+4917662465779",
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Ready-To-Test",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.20625,
           52.53866
         ],
@@ -12550,29 +11844,6 @@
         "title": "Schnelltest Altstadt Spandau",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.43846,
-          52.54289
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Naugarder Straße 45, 10409 Berlin",
-        "telephone": null,
-        "details_url": "https://schnelltest15.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 11:00-17:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "schnelltest15 Naugarder Straße 45",
-        "hints": [
-          "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
@@ -12698,29 +11969,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.42357,
-          52.48855
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Urbanstraße 86, 10967 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Tu 09:00-18:00; Sa 09:00-18:00; Th 09:00-18:00; We 09:00-18:00",
-        "title": "Schnelltest Kreuzberg Urbanstraße",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.43173,
           52.49702
         ],
@@ -12783,6 +12031,29 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.42357,
+          52.48855
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Urbanstraße 86, 10967 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Tu 09:00-18:00; Sa 09:00-18:00; Th 09:00-18:00; We 09:00-18:00",
+        "title": "Schnelltest Kreuzberg Urbanstraße",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -12922,6 +12193,29 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.25807,
+          52.43352
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Kirchstraße 1-3, 14163 Berlin",
+        "telephone": null,
+        "details_url": "https://www.stadtapotheke-berlin.de",
+        "opening_hours": "Fr 09:30-16:00; Mo 09:30-16:00; Tu 09:30-16:00; Sa 09:30-16:00; Th 09:30-16:00; We 09:30-16:00",
+        "title": "Stadt-Apotheke, Testzelt Rathausplatz",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -13206,29 +12500,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.37367,
-          52.50937
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Potsdamer Straße 2, 10785 Berlin",
-        "telephone": null,
-        "details_url": "https://berlin5.testcenter-corona.de",
-        "opening_hours": "Fr 10:00-18:00; Mo 08:00-16:00; Su 10:00-16:00; Tu 08:00-16:00; Sa 10:00-18:00; Th 08:00-16:00; We 08:00-16:00",
-        "title": "Testcenter Corona Potsdamer Str.",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.30766,
           52.501
         ],
@@ -13363,6 +12634,29 @@
           "Terminbuchung: optional"
         ],
         "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.29735,
+          52.50679
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Kantstraße 88, 10627 Berlin",
+        "telephone": null,
+        "details_url": "https://anny.co/b/testzentrum-kantstrasse",
+        "opening_hours": "Fr 09:00-21:00; Mo 09:00-21:00; Tu 09:00-21:00; Sa 09:00-21:00; Th 09:00-21:00; We 09:00-21:00",
+        "title": "Teststation Kantstrasse",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
       },
       "type": "Feature"
     },
@@ -13507,22 +12801,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.6246299984999,
-          52.532966927013
+          13.3301,
+          52.52731
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Jänschwalder Straße 4, 12627 Berlin",
+        "location": "Turmstraße 56, 10551 Berlin",
         "telephone": null,
-        "details_url": "https://21dx.de/corona-test-berlin-pcr-antigen.html",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testzentrum Marzahn-Hellersdorf",
+        "details_url": "https://anny.co/b/teststation-turmstrasse",
+        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
+        "title": "Teststation Turmstrasse",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -13699,8 +12993,8 @@
       "properties": {
         "location": "Franz-Jacob-Straße 12, 10369 Berlin",
         "telephone": null,
-        "details_url": "https://berlintesten.covidservicepoint.de/logout",
-        "opening_hours": "Fr 07:30-20:30; Mo 07:30-20:30; Tu 07:30-20:30; Th 07:30-20:30; We 07:30-20:30",
+        "details_url": "https://berlintesten.covidservicepoint.de",
+        "opening_hours": "Fr 07:30-20:30; Mo 07:30-20:30; Su 10:00-17:00; Tu 07:30-20:30; Sa 10:00-17:00; Th 07:30-20:30; We 07:30-20:30",
         "title": "Testzentrum am Anton Saefkow Platz",
         "hints": [
           "PCR-Nachtestung: ja",
@@ -13737,29 +13031,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.36349,
-          52.48599
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Naumannstraße 4, 10829 Berlin",
-        "telephone": null,
-        "details_url": "https://testzentrum-freunde.de",
-        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Tu 09:00-18:00; Sa 09:00-18:00; Th 09:00-18:00; We 09:00-18:00",
-        "title": "Testzentrum-Freunde3",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.48416,
           52.43853
         ],
@@ -13776,29 +13047,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.38753,
-          52.5036
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Wilhelmstraße 22, 10963 Berlin",
-        "telephone": "0179 8297202",
-        "details_url": "https://restaurant-asador.de/de/frontpage",
-        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Su 11:00-19:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
-        "title": "Testzentrum Checkpoint Charlie",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -13875,29 +13123,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.4242400984979,
-          52.472561955353
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Leinestraße 37-45, 12049 Berlin",
-        "telephone": null,
-        "details_url": "https://21dx.de/corona-test-berlin-pcr-antigen.html",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testzentrum Neukölln",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.40821,
           52.54905
         ],
@@ -13914,6 +13139,52 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.36349,
+          52.48599
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Naumannstraße 4, 10829 Berlin",
+        "telephone": null,
+        "details_url": "https://testzentrum-freunde.de",
+        "opening_hours": "Fr 10:30-17:00; Mo 10:30-17:00; Su 11:00-14:00; Tu 10:30-17:00; Sa 11:00-14:00; Th 10:30-17:00; We 10:30-17:00",
+        "title": "Testzentrum-Freunde3",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.38753,
+          52.5036
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Wilhelmstraße 22, 10963 Berlin",
+        "telephone": "0179 8297202",
+        "details_url": "https://restaurant-asador.de/de/frontpage",
+        "opening_hours": "Fr 10:00-16:00; Mo 10:00-16:00; Su 11:00-16:00; Tu 10:00-16:00; Sa 10:00-16:00; Th 10:00-16:00; We 10:00-16:00",
+        "title": "Testzentrum Checkpoint Charlie",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -13983,29 +13254,6 @@
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.31377,
-          52.50552
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Leibnizstraße 68, 10625 Berlin",
-        "telephone": null,
-        "details_url": "https://www.testzentrum-leibniz.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Testzentrum-Leibniz",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
       },
@@ -14099,52 +13347,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.47049,
-          52.53274
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Landsberger Allee 177, 10369 Berlin",
-        "telephone": "015223663001",
-        "details_url": "https://ww.testzentrum-tower.de",
-        "opening_hours": "Fr 08:00-21:00; Mo 08:00-21:00; Su 08:00-21:00; Tu 08:00-21:00; Sa 08:00-21:00; Th 08:00-21:00; We 08:00-21:00",
-        "title": "Testzentrum Tower",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.37732,
-          52.55658
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Osloer Straße 33, 13359 Berlin",
-        "telephone": null,
-        "details_url": "https://testzentrumroyal.de",
-        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Su 09:00-18:00; Tu 09:00-18:00; Sa 09:00-18:00; Th 09:00-18:00; We 09:00-18:00",
-        "title": "Testzentrum Wedding",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -14543,29 +13745,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.45394,
-          52.42974
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Johannisthaler Chaussee 326, 12351 Berlin",
-        "telephone": null,
-        "details_url": "https://event-coronatest.covidservicepoint.de",
-        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 08:00-19:00; Tu 08:00-19:00; Sa 08:00-19:00; Th 08:00-19:00; We 08:00-19:00",
-        "title": "Event-Coronatest Gropius Passagen",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.40382,
           52.54046
         ],
@@ -14681,29 +13860,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.40783,
-          52.50218
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Ritterstraße 24, 10969 Berlin",
-        "telephone": null,
-        "details_url": "https://15minutentest.de",
-        "opening_hours": "Fr 07:00-12:00, 15:00-20:00; Mo 07:00-12:00, 15:00-20:00; Su 10:00-18:00; Tu 07:00-12:00, 15:00-20:00; Sa 10:00-18:00; Th 07:00-12:00, 15:00-20:00; We 07:00-12:00, 15:00-20:00",
-        "title": "15Minutentest-Berlin-Kreuzberg",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.38192,
           52.52295
         ],
@@ -14715,52 +13871,6 @@
         "details_url": "https://www.instagram.com/schnelltestberlinmitte",
         "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
         "title": "Corona Teststation Berlin Mitte",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.44193,
-          52.51741
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Karl-Marx-Allee 93, 10243 Berlin",
-        "telephone": null,
-        "details_url": "https://www.testzentrum-weberwiese.de",
-        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 09:00-18:00; Tu 07:00-19:00; Sa 07:00-19:00; Th 07:00-19:00; We 07:00-19:00",
-        "title": "Testzentrum Weberwiese",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.37474,
-          52.51021
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Bellevuestraße 1, 10785 Berlin",
-        "telephone": null,
-        "details_url": "https://www.stadtapotheke-berlin.de",
-        "opening_hours": "Fr 08:00-17:00; Mo 09:00-17:00; Tu 09:00-17:00; Sa 10:00-16:00; Th 09:00-17:00; We 09:00-17:00",
-        "title": "10785 Testzentrum Sony Center",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -14911,20 +14021,20 @@
     {
       "geometry": {
         "coordinates": [
-          13.45595,
-          52.51191
+          13.44193,
+          52.51741
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Grünberger Straße 54, 10245 Berlin",
+        "location": "Karl-Marx-Allee 93, 10243 Berlin",
         "telephone": null,
-        "details_url": "https://schnelltest15.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00, 11:00-17:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "schnelltest 15 Grünberger Straße 54",
+        "details_url": "https://www.testzentrum-weberwiese.de",
+        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 09:00-18:00; Tu 07:00-19:00; Sa 07:00-19:00; Th 07:00-19:00; We 07:00-19:00",
+        "title": "Testzentrum Weberwiese",
         "hints": [
           "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
+          "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
@@ -15003,29 +14113,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.35294,
-          52.53994
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Kiautschoustraße 12A, 13353 Berlin",
-        "telephone": null,
-        "details_url": "https://www.fastandsafe-medicare.de",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Fast & Safe Kiautschoustraße",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.38799,
           52.54885
         ],
@@ -15087,52 +14174,6 @@
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.5255461850041,
-          52.4553416763626
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Ernst-Ziesel-Straße 1, 12459 Berlin",
-        "telephone": null,
-        "details_url": "https://21dx.de/corona-test-berlin-pcr-antigen.html",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testzentrum Oberschöneweide",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2118048561712,
-          52.5402509785449
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Am Juliusturm 64, 13599 Berlin",
-        "telephone": null,
-        "details_url": "https://21dx.de/corona-test-berlin-pcr-antigen.html",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testzentrum Spandau",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
           "Terminbuchung: nicht notwendig"
         ]
       },
@@ -15304,8 +14345,8 @@
     {
       "geometry": {
         "coordinates": [
-          13.30223,
-          52.43797
+          13.302519740543,
+          52.4382862107677
         ],
         "type": "Point"
       },
@@ -15327,20 +14368,20 @@
     {
       "geometry": {
         "coordinates": [
-          13.51128,
-          52.45779
+          13.44313,
+          52.48014
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Brückenstraße 7, 12439 Berlin",
-        "telephone": null,
-        "details_url": "https://www.tak-togo.de",
+        "location": "Sonnenallee 128, 12059 Berlin",
+        "telephone": "+491782596386",
+        "details_url": null,
         "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 07:00-18:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
-        "title": "T.A.K SPUCK TO GO Brückenstr.",
+        "title": "T.A.K",
         "hints": [
           "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
+          "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
         ]
@@ -15396,6 +14437,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.51128,
+          52.45779
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Brückenstraße 7, 12439 Berlin",
+        "telephone": null,
+        "details_url": "https://www.tak-togo.de",
+        "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 07:00-18:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
+        "title": "T.A.K SPUCK TO GO Brückenstr.",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.41726,
           52.54018
         ],
@@ -15412,29 +14476,6 @@
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.38287,
-          52.49188
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Großbeerenstraße 35, 10965 Berlin",
-        "telephone": null,
-        "details_url": "https://www.coronaschnelltests-in-berlin.de/grossbeerenstrasse-schnelltest",
-        "opening_hours": "Fr 07:00-19:30; Mo 07:00-19:30; Su 08:00-19:30; Tu 07:00-19:30; Sa 08:00-19:30; Th 07:00-19:30; We 07:00-19:30",
-        "title": "Covid Testzentrum am Mehringdamm",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -15481,52 +14522,6 @@
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3032,
-          52.55215
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Kurt-Schumacher-Damm 207, 13405 Berlin",
-        "telephone": "015154683531",
-        "details_url": "https://coronatest24.org/#",
-        "opening_hours": "Fr 12:00-21:00; Su 12:00-21:00; Sa 12:00-21:00; Th 12:00-21:00; We 12:00-21:00",
-        "title": "CoronaTest24 Am Festplatz",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.30691,
-          52.50587
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Wilmersdorfer Straße 108-111, 10627 Berlin",
-        "telephone": null,
-        "details_url": "https://www.schnelltest-in-berlin.de",
-        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
-        "title": "Schnelltest Station Joachimstaler Platz Ecke Kurfürstendamm",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
           "Terminbuchung: nicht notwendig"
         ]
       },
@@ -15582,17 +14577,63 @@
     {
       "geometry": {
         "coordinates": [
-          13.49766,
-          52.50941
+          13.45198,
+          52.50841
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Weitlingstr. 22, 10317 Berlin",
+        "location": "Revaler Straße 99, 10245 Berlin",
         "telephone": null,
-        "details_url": "https://www.schnelltests-berlin.com",
-        "opening_hours": "Fr 10:00-18:00; Mo 10:00-18:00; Su 10:00-18:00; Tu 10:00-18:00; Sa 10:00-18:00; Th 10:00-18:00; We 10:00-18:00",
-        "title": "BG Lichtenberg",
+        "details_url": "https://www.mycoronatest.berlin",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "myCoronatest Revaler Straße",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.53672,
+          52.53271
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Märkische Allee 161, 12681 Berlin",
+        "telephone": null,
+        "details_url": "https://www.bürgertest-corona.de",
+        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Su 09:00-20:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
+        "title": "POCO-Einkaufsmarkt-Marzahn",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3308599,
+          52.5034487
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Joachimsthaler Platz, 10627 Berlin",
+        "telephone": null,
+        "details_url": "https://www.schnelltest-in-berlin.de",
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "Schnelltest Station Joachimstaler Platz Ecke Kurfürstendamm",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
@@ -15761,29 +14802,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.29453,
-          52.50074
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Karlsruher Straße 20, 10711 Berlin",
-        "telephone": null,
-        "details_url": "https://www.stadtapotheke-berlin.de",
-        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Tu 09:00-19:00; Sa 10:00-16:00; Th 09:00-19:00; We 09:00-19:00",
-        "title": "10711 Teststation Aspria",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -16021,29 +15039,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3547943985004,
-          52.548501135274
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Müllerstraße 143, 13353 Berlin",
-        "telephone": null,
-        "details_url": "https://21dx.de/corona-test-berlin-pcr-antigen.html",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testzentrum Wedding",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.38742,
           52.48979
         ],
@@ -16215,31 +15210,8 @@
         "location": "Treskowallee 8, 10318 Berlin",
         "telephone": null,
         "details_url": "https://21dx.de/corona-test-berlin-pcr-antigen.html",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "opening_hours": "Fr 08:00-17:00; Mo 08:00-17:00; Su 08:00-17:00; Tu 08:00-17:00; Sa 08:00-17:00; Th 08:00-17:00; We 08:00-17:00",
         "title": "Testzentrum Lichtenberg",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.4685829829253,
-          52.5150588345049
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Frankfurter Allee 71-77, 10247 Berlin",
-        "telephone": null,
-        "details_url": "https://21dx.de/corona-test-berlin-pcr-antigen.html",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-17:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testzentrum Plaza",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -16337,29 +15309,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3861674829056,
-          52.5217579517463
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Schiffbauerdamm 5, 10117 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
-        "title": "10117 Teststation Schiffbauerdamm",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -16483,6 +15432,53 @@
     {
       "geometry": {
         "coordinates": [
+          13.3063621919996,
+          52.4473358370923
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Moltkestraße 53, 12203 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": null,
+        "title": "Moltkestraße53",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3861674829056,
+          52.5217579517463
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schiffbauerdamm 5, 10117 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "10117 Teststation Schiffbauerdamm",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.5117,
           52.43374
         ],
@@ -16576,6 +15572,52 @@
     {
       "geometry": {
         "coordinates": [
+          13.42227,
+          52.47583
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schillerpromenade 11, 12049 Berlin",
+        "telephone": null,
+        "details_url": "https://testzentrum-berlin-neukoelln.de",
+        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
+        "title": "Tesetzentrum Berlin Neukölln",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3248,
+          52.4865
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Berliner Straße 143, 10715 Berlin",
+        "telephone": null,
+        "details_url": "https://covid19testzentrumberlin.de",
+        "opening_hours": "Fr 08:00-22:00; Mo 08:00-22:00; Su 08:00-22:00; Tu 08:00-22:00; Sa 08:00-22:00; Th 08:00-22:00; We 08:00-22:00",
+        "title": "Covid19 Testzentrum Berlin",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.30926,
           52.51113
         ],
@@ -16623,52 +15665,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.42227,
-          52.47583
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Schillerpromenade 11, 12049 Berlin",
-        "telephone": null,
-        "details_url": "https://testzentrum-berlin-neukoelln.de",
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Tesetzentrum Berlin Neukölln",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3248,
-          52.4865
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Berliner Straße 143, 10715 Berlin",
-        "telephone": null,
-        "details_url": "https://covid19testzentrumberlin.de",
-        "opening_hours": "Fr 08:00-22:00; Mo 08:00-22:00; Su 08:00-22:00; Tu 08:00-22:00; Sa 08:00-22:00; Th 08:00-22:00; We 08:00-22:00",
-        "title": "Covid19 Testzentrum Berlin",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.30668,
           52.52521
         ],
@@ -16680,52 +15676,6 @@
         "details_url": "https://norona-berlin.covidservicepoint.de",
         "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
         "title": "Norona-Mierendorff",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.29522,
-          52.496619
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Westfälische Str. 56, 10117 Berlin",
-        "telephone": "+49151 71 331 350",
-        "details_url": "https://norona-berlin.covidservicepoint.de",
-        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
-        "title": "Norona-Westfälische",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.31842,
-          52.48796
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Brandenburgische Str. 77, 10713 Berlin",
-        "telephone": "+49151 71 331 350",
-        "details_url": "https://norona-berlin.covidservicepoint.de",
-        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
-        "title": "Norona-Brandenburgische",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: keine Angabe",
@@ -16785,30 +15735,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.1645822339631,
-          52.5507705754233
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Falkenseer Chaussee 199, 0 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": null,
-        "title": "Teststelle Falkensee",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.38277,
           52.55179
         ],
@@ -16855,20 +15781,44 @@
     {
       "geometry": {
         "coordinates": [
-          13.2968,
-          52.54017
+          13.1645822339631,
+          52.5507705754233
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Heckerdamm 240, 13627 Berlin",
-        "telephone": "030 / 3435 7474",
-        "details_url": "https://www.fairlife-berlin.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-18:00; Tu 08:00-20:00; Sa 10:00-18:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Fairlife Test Station",
+        "location": "Falkenseer Chaussee 199, 0 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": null,
+        "title": "Teststelle Falkensee",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.29522,
+          52.496619
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Westfälische Str. 56, 10117 Berlin",
+        "telephone": "+49151 71 331 350",
+        "details_url": "https://norona-berlin.covidservicepoint.de",
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "Norona-Westfälische",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
@@ -16878,22 +15828,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.3077489998726,
-          52.5048569916057
+          13.31842,
+          52.48796
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Wilmersdorfer Str. 107, 10629 Berlin",
-        "telephone": "015214582764",
-        "details_url": "https://www.testgiganten.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-18:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Testgiganten Wilmersdorf",
+        "location": "Brandenburgische Str. 77, 10713 Berlin",
+        "telephone": "+49151 71 331 350",
+        "details_url": "https://norona-berlin.covidservicepoint.de",
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "Norona-Brandenburgische",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
+          "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -16938,29 +15888,6 @@
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.45577,
-          52.47396
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Sonnenallee 220, 12059 Berlin",
-        "telephone": null,
-        "details_url": "https://2goteststation@gmail.com",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Teststation",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
         ]
@@ -17016,30 +15943,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.37378,
-          52.55661
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Osloer Straße 84, 13359 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": null,
-        "title": "Testzentrum Osloer",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.49361,
           52.53314
         ],
@@ -17086,29 +15989,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.20711,
-          52.54432
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Neuendorfer Straße 12, 13585 Berlin",
-        "telephone": null,
-        "details_url": "https://testzentrumoyal.de",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 09:00-17:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testzentrum Neuendorfer",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.32445,
           52.45796
         ],
@@ -17122,6 +16002,76 @@
         "title": "Düppel Schnelltestzentrum",
         "hints": [
           "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.45577,
+          52.47396
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Sonnenallee 220, 12059 Berlin",
+        "telephone": null,
+        "details_url": "https://2goteststation@gmail.com",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Teststation",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.37378,
+          52.55661
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Osloer Straße 84, 13359 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": null,
+        "title": "Testzentrum Osloer",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.20711,
+          52.54432
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Neuendorfer Straße 12, 13585 Berlin",
+        "telephone": null,
+        "details_url": "https://testzentrumoyal.de",
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 09:00-17:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "Testzentrum Neuendorfer",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
@@ -17340,29 +16290,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.21481,
-          52.53827
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Am Juliusturm 55-59, 13599 Berlin",
-        "telephone": null,
-        "details_url": "https://www.testzentrumroyal.de",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 10:00-16:00; Tu 08:00-18:00; Sa 10:00-16:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testzentrum Royal",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.55091,
           52.46554
         ],
@@ -17434,30 +16361,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.37723,
-          52.46359
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Manteuffelstraße 11, 12103 Berlin",
-        "telephone": null,
-        "details_url": "https://manteufelstr11-covidtest-berlin.com",
-        "opening_hours": null,
-        "title": "Manteufelstr 11",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.4461,
           52.52613
         ],
@@ -17481,20 +16384,20 @@
     {
       "geometry": {
         "coordinates": [
-          13.38416,
-          52.48504
+          13.37723,
+          52.46359
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Dudenstraße 11, 10965 Berlin",
+        "location": "Manteuffelstraße 11, 12103 Berlin",
         "telephone": null,
-        "details_url": null,
+        "details_url": "https://manteufelstr11-covidtest-berlin.com",
         "opening_hours": null,
-        "title": "Cartal Medical Dudenstr.",
+        "title": "Manteuffelstr 11",
         "hints": [
           "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
+          "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ],
@@ -17505,68 +16408,45 @@
     {
       "geometry": {
         "coordinates": [
-          13.3609725,
-          52.5668399
+          13.36619,
+          52.56324
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Residenzstr. 123, 13409 Berlin",
+        "location": "Letteallee 6, 13409 Berlin",
         "telephone": null,
         "details_url": null,
-        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Su 09:00-20:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
-        "title": "Testcenter Residenzstr. 123",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.37349,
-          52.56572
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Reginhardstraße 98, 13409 Berlin",
-        "telephone": null,
-        "details_url": "http://www.teststation-reginhardstrasse.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-18:00; Tu 08:00-20:00; Sa 10:00-18:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Schnelltest Reginhard",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.35426,
-          52.59705
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Wilhelmsruher Damm 140, 13439 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "ProfisamStart Test-To-Go",
+        "opening_hours": "Fr 10:00-21:00; Mo 10:00-21:00; Su 10:00-21:00; Tu 10:00-21:00; Sa 10:00-21:00; Th 10:00-21:00; We 10:00-21:00",
+        "title": "Teststation Residenzstraße",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.38416,
+          52.48504
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Dudenstraße 11, 10965 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 12:00-18:00; Tu 07:00-19:00; Sa 07:00-19:00; Th 07:00-19:00; We 07:00-19:00",
+        "title": "Cartal Medical Dudenstr.",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -17587,29 +16467,6 @@
         "title": "Corona Speedtest",
         "hints": [
           "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.36619,
-          52.56324
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Letteallee 6, 13409 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 10:00-21:00; Mo 10:00-21:00; Su 10:00-21:00; Tu 10:00-21:00; Sa 10:00-21:00; Th 10:00-21:00; We 10:00-21:00",
-        "title": "Teststation Residenzstraße",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
@@ -17643,45 +16500,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.36462,
-          52.49369
+          13.3609725,
+          52.5668399
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Goebenstraße 10, 10783 Berlin",
-        "telephone": "+4917678513700",
-        "details_url": "https://yorckstr.covidtest-berlin.com",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Yorckstraße",
+        "location": "Residenzstraße 123, 13409 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Su 09:00-20:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
+        "title": "Testcenter Residenzstr. 123",
         "hints": [
-          "PCR-Nachtestung: ja",
+          "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.396639304663,
-          52.4232934730996
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Mariendorfer Damm 341, 12107 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-17:00; Mo 08:00-17:00; Su 10:00-16:00; Tu 08:00-17:00; Sa 10:00-16:00; Th 08:00-17:00; We 08:00-17:00",
-        "title": "Corona Teststation Immelmann Mariendorfer Damm",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -17758,52 +16592,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.36268,
-          52.56783
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Residenzstraße 125, 13409 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 07:00-22:00; Mo 07:00-20:00; Su 10:00-20:00; Tu 07:00-20:00; Sa 10:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "ResiTestZentrum",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.31012,
-          52.5719
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Antonienstr. 61, 13403 Berlin",
-        "telephone": null,
-        "details_url": "https://www.Testcenter-veithi.de",
-        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Su 09:00-19:00; Tu 09:00-19:00; Sa 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
-        "title": "Testcenter Vaithi",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.3299,
           52.56927
         ],
@@ -17820,6 +16608,75 @@
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.31012,
+          52.5719
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Antonienstraße 61, 13403 Berlin",
+        "telephone": null,
+        "details_url": "https://www.Testcenter-veithi.de",
+        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Su 09:00-19:00; Tu 09:00-19:00; Sa 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
+        "title": "Testcenter Vaithi",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.396639304663,
+          52.4232934730996
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Mariendorfer Damm 341, 12107 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-17:00; Mo 08:00-17:00; Su 10:00-16:00; Tu 08:00-17:00; Sa 10:00-16:00; Th 08:00-17:00; We 08:00-17:00",
+        "title": "Corona Teststation Immelmann Mariendorfer Damm",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.36462,
+          52.49369
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Goebenstraße 10, 10783 Berlin",
+        "telephone": "+4917678513700",
+        "details_url": "https://yorckstr.covidtest-berlin.com",
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "Yorckstraße",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -17942,29 +16799,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.28585,
-          52.58869
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Grußdorfstraße 14, 13507 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-18:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Teststation-Grussdorf",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.4505,
           52.54879
         ],
@@ -18011,29 +16845,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.31389,
-          52.56793
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Scharnweberstr. 57, 13405 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Su 09:00-20:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
-        "title": "Testcentrumfc Scharnweberstraße",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.3281,
           52.56308
         ],
@@ -18057,29 +16868,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.36254,
-          52.59592
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Tiefenseerstraße 2, 13439 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:30-16:30; Mo 08:30-16:30; Su 08:30-14:30; Tu 08:30-16:30; Sa 08:30-16:30; Th 08:30-16:30; We 08:30-16:30",
-        "title": "StationC",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.20775,
           52.54796
         ],
@@ -18096,29 +16884,6 @@
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.28031,
-          52.58934
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Alt Tegeler 14, 13507 Berlin",
-        "telephone": "+49 163 2336695",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Teststation Alttegel",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -18241,52 +17006,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.203,
-          52.53789
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Moritzstraße 23, 13597 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 10:00-23:00; Mo 10:00-20:00; Su 10:00-18:00; Tu 10:00-20:00; Sa 10:00-23:00; Th 10:00-20:00; We 10:00-20:00",
-        "title": "TESTPOINT",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.32975,
-          52.56824
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Ollenhauer Str. 23, 13403 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
-        "title": "Norona-Ollenhauer",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.35045,
           52.41468
         ],
@@ -18325,29 +17044,6 @@
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.34132,
-          52.53131
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Wilhelmshavener Straße 24, 10551 Berlin",
-        "telephone": null,
-        "details_url": "https://www.teststation-berlin.com",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Teststation Berlin",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
       },
@@ -18471,22 +17167,45 @@
     {
       "geometry": {
         "coordinates": [
-          13.29158,
-          52.57986
+          13.34132,
+          52.53131
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Biedekopfer Straße 1, 13507 Berlin",
+        "location": "Wilhelmshavener Straße 24, 10551 Berlin",
         "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-21:00; Mo 08:00-21:00; Su 08:00-21:00; Tu 08:00-21:00; Sa 08:00-21:00; Th 08:00-21:00; We 08:00-21:00",
-        "title": "Corona Speedtest",
+        "details_url": "https://www.teststation-berlin.com",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Teststation Berlin",
         "hints": [
           "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
+          "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.32975,
+          52.56824
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Ollenhauer Str. 23, 13403 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "Norona-Ollenhauer",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -18517,29 +17236,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.35447,
-          52.60202
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Senftenberger Ring 15, 13439 Berlin",
-        "telephone": null,
-        "details_url": "http://www.intermedicaltestcenter.de",
-        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Tu 07:00-21:00; Sa 07:00-21:00; Th 07:00-21:00; We 07:00-21:00",
-        "title": "Testzentrum ALDI Senftenberger Ring 15",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.33469,
           52.58899
         ],
@@ -18554,52 +17250,6 @@
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.31895,
-          52.61046
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Oraniendamm 46, 13469 Berlin",
-        "telephone": null,
-        "details_url": "http://www.intermedicaltestcenter.de",
-        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Tu 07:00-21:00; Sa 07:00-21:00; Th 07:00-21:00; We 07:00-21:00",
-        "title": "Testzentrum ALDI Oraniendamm 46",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.18392,
-          52.52683
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Seeburger Str. 65, 13581 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 10:00-19:00; Mo 10:00-19:00; Su 10:00-19:00; Tu 10:00-19:00; Sa 10:00-19:00; Th 10:00-19:00; We 10:00-19:00",
-        "title": "Test to go Station",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
         ]
@@ -18678,19 +17328,19 @@
     {
       "geometry": {
         "coordinates": [
-          13.29879,
-          52.578
+          13.29158,
+          52.57986
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Holzhauser Straße 26, 13509 Berlin",
-        "telephone": "01520 3873038",
-        "details_url": "http://www.intermedicaltestcenter.de",
-        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Tu 07:00-21:00; Sa 07:00-21:00; Th 07:00-21:00; We 07:00-21:00",
-        "title": "Testzentrum ALDI Holzhauser Str. 26",
+        "location": "Biedekopfer Straße 1, 13507 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-21:00; Mo 08:00-21:00; Su 08:00-21:00; Tu 08:00-21:00; Sa 08:00-21:00; Th 08:00-21:00; We 08:00-21:00",
+        "title": "Corona Speedtest",
         "hints": [
-          "PCR-Nachtestung: keine Angabe",
+          "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
@@ -18711,7 +17361,7 @@
         "telephone": null,
         "details_url": "https://www.border-point.de",
         "opening_hours": "Fr 08:00-22:00; Mo 08:00-22:00; Su 08:00-22:00; Tu 08:00-22:00; Sa 08:00-22:00; Th 08:00-22:00; We 08:00-22:00",
-        "title": "Corona Border Point Wilhemsruher Damm",
+        "title": "Corona Border Point",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: keine Angabe",
@@ -18977,29 +17627,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.18322,
-          52.53512
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Brunsbütteler Damm 108, 13581 Berlin",
-        "telephone": null,
-        "details_url": "https://www.as-covid-testzentrum.de",
-        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Su 09:00-15:00; Tu 09:00-18:00; Sa 09:00-18:00; Th 09:00-18:00; We 09:00-18:00",
-        "title": "AS Covid Testzentrum",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.42261,
           52.5008
         ],
@@ -19138,29 +17765,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.376935,
-          52.516181
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Seegefelderstr. 79, 13583 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Testcentrumfc Seegefelderstraße",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.34507,
           52.53001
         ],
@@ -19220,52 +17824,6 @@
         "title": "Schnelltest Kreuzberg",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.42802,
-          52.47319
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Hermannstraße 78, 12049 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 10:00-18:00; Tu 07:00-19:00; Sa 09:00-19:00; Th 07:00-19:00; We 07:00-19:00",
-        "title": "Hermannstr. 78",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.36859,
-          52.54894
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Reinickendorfer Straße 91b, 13347 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 10:00-19:00; Mo 10:00-19:00; Su 10:00-19:00; Tu 10:00-19:00; Sa 10:00-19:00; Th 10:00-19:00; We 10:00-19:00",
-        "title": "MyTest Teststation",
-        "hints": [
-          "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
@@ -19368,6 +17926,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.42802,
+          52.47319
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Hermannstraße 78, 12049 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 10:00-18:00; Tu 07:00-19:00; Sa 09:00-19:00; Th 07:00-19:00; We 07:00-19:00",
+        "title": "Hermannstr. 78",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.32823,
           52.56544
         ],
@@ -19384,75 +17965,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.35714,
-          52.56215
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Vierwaldstätter Weg / Holländerstraße, 13407 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-21:00; Mo 08:00-21:00; Su 08:00-21:00; Tu 08:00-21:00; Sa 08:00-21:00; Th 08:00-21:00; We 08:00-21:00",
-        "title": "Ready to Test",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.331,
-          52.59761
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Cyclopstraße 1-5, 13437 Berlin",
-        "telephone": "0176 62465779",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-21:00; Mo 08:00-21:00; Su 08:00-21:00; Tu 08:00-21:00; Sa 08:00-21:00; Th 08:00-21:00; We 08:00-21:00",
-        "title": "Ready to Test",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.26684,
-          52.63221
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Sigismundkorsostraße 42-45, 13465 Berlin",
-        "telephone": "0176 62465779",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-21:00; Mo 08:00-21:00; Su 08:00-21:00; Tu 08:00-21:00; Sa 08:00-21:00; Th 08:00-21:00; We 08:00-21:00",
-        "title": "Ready to Test",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -19529,29 +18041,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3079,
-          52.50143
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Wilmersdorferstr. 94, 10629 Berlin",
-        "telephone": "0152 128 269 16",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-21:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-21:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Corona Testzentrum Adenauerplatz",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.38348,
           52.55571
         ],
@@ -19599,6 +18088,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.36829,
+          52.43638
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Lankwitzer Straße 59, 12107 Berlin",
+        "telephone": "01782596386",
+        "details_url": null,
+        "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 07:00-18:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
+        "title": "T.A.K 3",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.36031,
           52.5508
         ],
@@ -19612,29 +18124,6 @@
         "title": "Schnell-Test-Berlin",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.32746,
-          52.50468
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Fasanenstr. 14, 10623 Berlin",
-        "telephone": null,
-        "details_url": "https://www.testing-now.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Testing Now",
-        "hints": [
-          "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
@@ -19679,52 +18168,6 @@
         "details_url": "https://corona-testservice.berlin",
         "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
         "title": "TM Testzentrum - GLS Sprachschule - Kastanienallee",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.19514,
-          52.52105
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Adamstr. 43, 13595 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Testzentrum KA",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.45255,
-          52.51192
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Warschauer Straße 71, 10243 Berlin",
-        "telephone": null,
-        "details_url": "https://kalacafeberlin.wixsite.com",
-        "opening_hours": "Fr 08:00-17:00; Mo 08:00-17:00; Tu 08:00-17:00; Sa 08:00-17:00; Th 08:00-17:00; We 08:00-17:00",
-        "title": "KalaTest",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -19783,17 +18226,17 @@
     {
       "geometry": {
         "coordinates": [
-          13.35,
-          52.58511
+          13.45255,
+          52.51192
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Lengender Straße 17-19, 13407 Berlin",
+        "location": "Warschauer Straße 71, 10243 Berlin",
         "telephone": null,
-        "details_url": "http://www.mycoronatest.berlin",
-        "opening_hours": "Fr 07:30-19:30; Mo 07:30-19:30; Tu 07:30-19:30; Th 07:30-19:30; We 07:30-19:30",
-        "title": "(2184) myCoronaTest-Reinickendorf",
+        "details_url": "https://kalacafeberlin.wixsite.com",
+        "opening_hours": "Fr 08:00-17:00; Mo 08:00-17:00; Tu 08:00-17:00; Sa 08:00-17:00; Th 08:00-17:00; We 08:00-17:00",
+        "title": "KalaTest",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -19954,7 +18397,7 @@
         "telephone": null,
         "details_url": "https://www.mycoronatest.berlin",
         "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 07:00-18:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
-        "title": "(637) myCoronatest Rosenthaler Str.",
+        "title": "myCoronatest Rosenthaler Str.",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -19980,75 +18423,6 @@
         "title": "Sapoto Testzenter Biesdorf",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.31278,
-          52.5261
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Kaiserin-Augusta-Allee 35, 10589 Berlin",
-        "telephone": "+49176 72708064",
-        "details_url": null,
-        "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 07:00-22:00; Tu 07:00-22:00; Sa 07:00-22:00; Th 07:00-22:00; We 07:00-22:00",
-        "title": "Be Safe -Teststation Bürgertest Corona",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.46499,
-          52.52506
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Franz Jacob Straße 1, 10369 Berlin",
-        "telephone": null,
-        "details_url": "https://www.coronatestberlin.info",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Teststelle Storkower Bogen Mall",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.29546,
-          52.61051
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Hermsdorfer Damm 96, 13467 Berlin",
-        "telephone": "+491771963560",
-        "details_url": null,
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 08:00-20:00; Tu 07:00-20:00; Sa 08:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Teststation - Nord",
-        "hints": [
-          "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
@@ -20175,29 +18549,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.32135,
-          52.50172
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Knesebeckstr. 39-49, 10719 Berlin",
-        "telephone": null,
-        "details_url": "https://TestRoom-Berlin.de",
-        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 09:00-19:00; Tu 08:00-19:00; Sa 09:00-19:00; Th 08:00-19:00; We 08:00-19:00",
-        "title": "TestRoom Berlin",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.43709,
           52.57402
         ],
@@ -20267,75 +18618,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3206867984974,
-          52.4572096421463
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Schloßstraße 37, 12163 Berlin",
-        "telephone": null,
-        "details_url": "https://21dx.de/corona-test-berlin-pcr-antigen.html",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testzentrum Steglitz-Zehlendorf",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3850836273327,
-          52.4468543054673
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Mariendorfer Damm 64, 12109 Berlin",
-        "telephone": null,
-        "details_url": "https://21dx.de/corona-test-berlin-pcr-antigen.html",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-17:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testzentrum Tempelhof-Schöneberg",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3111567005557,
-          52.500939258405
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Kurfürstendamm 63, 10707 Berlin",
-        "telephone": null,
-        "details_url": "https://schnelltestberlin.de",
-        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Su 09:00-22:00; Tu 07:00-21:00; Sa 09:00-22:00; Th 07:00-21:00; We 07:00-21:00",
-        "title": "Schnelltest Berlin-Kudamm",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.21637,
           52.43989
         ],
@@ -20382,17 +18664,17 @@
     {
       "geometry": {
         "coordinates": [
-          13.4980754561742,
-          52.6317652447118
+          13.3206867984974,
+          52.4572096421463
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Groscurthstraße 29-33, 13125 Berlin",
+        "location": "Schloßstraße 37, 12163 Berlin",
         "telephone": null,
         "details_url": "https://21dx.de/corona-test-berlin-pcr-antigen.html",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Testzentrum Pankow",
+        "opening_hours": "Fr 08:00-17:00; Mo 08:00-17:00; Su 08:00-17:00; Tu 08:00-17:00; Sa 08:00-17:00; Th 08:00-17:00; We 08:00-17:00",
+        "title": "Testzentrum Steglitz-Zehlendorf",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -20417,33 +18699,10 @@
         "opening_hours": "Fr 10:00-18:00; Mo 10:00-18:00; Tu 10:00-18:00; Sa 10:00-13:00; Th 10:00-18:00; We 10:00-18:00",
         "title": "Krumme Lanke Apotheke",
         "hints": [
-          "PCR-Nachtestung: keine Angabe",
+          "PCR-Nachtestung: ja",
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.29546,
-          52.61051
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Hermsdorfer Damm 96, 13467 Berlin",
-        "telephone": "+491771963560",
-        "details_url": null,
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 08:00-20:00; Tu 07:00-20:00; Sa 08:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Teststation - Nord Mobil 2",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -20543,52 +18802,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3214547018589,
-          52.5013358890957
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Knesebeckstraße 39-49, 10719 Berlin",
-        "telephone": null,
-        "details_url": "https://testme-berlin.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-18:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "TestMe Berlin",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.311706765914,
-          52.5270390868732
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Kaiserin-Augusta-Allee 38, 10589 Berlin",
-        "telephone": null,
-        "details_url": "https://teststrasse123.de/services",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Tu 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Teststrasse123",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.46541,
           52.51828
         ],
@@ -20652,30 +18865,6 @@
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.31786,
-          52.43399
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Bäkestraße 15, 12207 Berlin",
-        "telephone": null,
-        "details_url": "https://www.wetestgermany.com",
-        "opening_hours": null,
-        "title": "WeTest Germany- Tomasa Lichterfelde",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ],
-        "opening_hours_unclassified": "Keine Angabe"
       },
       "type": "Feature"
     },
@@ -20752,75 +18941,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.19355,
-          52.53444
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Klosterstraße 3, 13581 Berlin",
-        "telephone": null,
-        "details_url": "https://coronapint.de/pages/corona-testzentrum-berlin-spandau-arcaden",
-        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Tu 09:00-19:00; Sa 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
-        "title": "Coronapoint- Spandau Arcaden",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3047600093456,
-          52.5030464969982
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Lewisham Str. 9, 10629 Berlin",
-        "telephone": null,
-        "details_url": "https://TestRoom-Berlin.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "TestRoom Berlin",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.29409,
-          52.47462
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Breite Straße 14, 14199 Berlin",
-        "telephone": null,
-        "details_url": "https://anny.co/b/book/testcenter-britta",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "BRITTA Covid Testcenter",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.52565,
           52.48158
         ],
@@ -20832,29 +18952,6 @@
         "details_url": "https://event-coronatest.de",
         "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 09:00-19:00; Tu 08:00-19:00; Sa 09:00-19:00; Th 08:00-19:00; We 08:00-19:00",
         "title": "Event-Coronatest Karlshorst",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.4991089556958,
-          52.5269356259965
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Herzbergstraße 105, 10365 Berlin",
-        "telephone": "+49157 360 30000",
-        "details_url": "https://www.testfast.de/book/herz-testcenter",
-        "opening_hours": "Fr 10:00-17:00; Mo 10:00-17:00; Su 10:00-17:00; Tu 10:00-17:00; Sa 10:00-17:00; Th 10:00-17:00; We 10:00-17:00",
-        "title": "Herz Testcenter",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
@@ -21074,29 +19171,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.5253371884963,
-          52.4830992670899
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Treskowallee 106,, 10318 Berlin",
-        "telephone": null,
-        "details_url": "https://event-coronatest.de",
-        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 09:00-19:00; Tu 08:00-19:00; Sa 09:00-19:00; Th 08:00-19:00; We 08:00-19:00",
-        "title": "DP Biomed UG",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.346416513366,
           52.5038334253986
         ],
@@ -21111,29 +19185,6 @@
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2796938470623,
-          52.5102043070683
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Meerscheidtstr. 9-11, 14050 Berlin",
-        "telephone": "01575868225",
-        "details_url": "https://www.am-corona-testzentrum.de",
-        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Su 10:00-20:00; Tu 07:00-21:00; Sa 07:00-21:00; Th 07:00-21:00; We 07:00-21:00",
-        "title": "AM Corona Testzentrum Meerscheidtstraße",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
@@ -21258,114 +19309,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.3043820250112,
-          52.5160848633728
+          13.5253371884963,
+          52.4830992670899
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Wilmersdorfer Straße 16, 10585 Berlin",
+        "location": "Treskowallee 106, 10318 Berlin",
         "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "R&M Teststation",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2576410980214,
-          52.435084398815
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Martin-Buber-Str. 18, 14163 Berlin",
-        "telephone": "015150901899",
-        "details_url": "https://www.coronatestberlin.info",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Teststelle Martin-Buber-Straße",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.15479,
-          52.53328
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Brunsbütteler Damm 280, 13591 Berlin",
-        "telephone": "01624967179",
-        "details_url": "https://testedichschnell.de/berlin-brunsbuetteler-damm",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Schnellteststation Brunsbütteler Damm",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3323979980235,
-          52.4935809833323
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Prager Platz 1-3, 10779 Berlin",
-        "telephone": null,
-        "details_url": "https://www.kostenloser-schnelltest-berlin.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Testzentrum Prager Passagen - Wilmersdorf",
+        "details_url": "https://event-coronatest.de",
+        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 09:00-19:00; Tu 08:00-19:00; Sa 09:00-19:00; Th 08:00-19:00; We 08:00-19:00",
+        "title": "DP Biomed UG",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.44067,
-          52.47358
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Karl-Marx-Platz, 12043 Berlin",
-        "telephone": null,
-        "details_url": "https://www.testzentrum-berlin.com",
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Karl-Marx-Platz walk and go Teststation",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -21442,45 +19401,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.29562,
-          52.57633
+          13.15479,
+          52.53328
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Holzhauser Straße 2, 13509 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 10:00-18:00; Tu 07:00-18:00; Sa 10:00-18:00; Th 07:00-18:00; We 07:00-18:00",
-        "title": "Holzhauser Straße",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3052752115177,
-          52.5128243032874
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Wilmersdorfer Straße 143, 10585 Berlin",
-        "telephone": null,
-        "details_url": "https://wirtesten.online/wd-coronatestzentrum",
-        "opening_hours": "Fr 06:00-20:00; Mo 06:00-20:00; Su 11:00-18:00; Tu 06:00-20:00; Sa 06:00-20:00; Th 06:00-20:00; We 06:00-20:00",
-        "title": "Testzentrum Wilmersdorf",
+        "location": "Brunsbütteler Damm 280, 13591 Berlin",
+        "telephone": "01624967179",
+        "details_url": "https://testedichschnell.de/berlin-brunsbuetteler-damm",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Schnellteststation Brunsbütteler Damm",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
+          "Tests für Kinder: ja",
+          "Terminbuchung: notwendig"
         ]
       },
       "type": "Feature"
@@ -21499,52 +19435,6 @@
         "details_url": "https://www.coronaschnelltest-gropiusstadt.de",
         "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 10:00-15:00; Tu 08:00-19:00; Sa 08:00-19:00; Th 08:00-19:00; We 08:00-19:00",
         "title": "Corona Schnelltest To Go Gropiusstadt",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2989603349233,
-          52.5004875411144
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Markgraf-Albrecht-Straße 8, 10711 Berlin",
-        "telephone": "+49 30 577 140 75",
-        "details_url": "https://deutschestestzentrum.de/charlottenburg",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Deutsches Testzentrum - Charlottenburg",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2861239863805,
-          52.5375770488072
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Halemweg 21, 13627 Berlin",
-        "telephone": null,
-        "details_url": "https://www.tt-testzentrum.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-18:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "TT-Testzentrum",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
@@ -21649,52 +19539,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3198777710364,
-          52.4848816180831
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Blissestraße 18, 10713 Berlin",
-        "telephone": null,
-        "details_url": "https://www.coronatest-blisse.de",
-        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 09:00-18:00; Tu 07:00-19:00; Sa 08:00-18:00; Th 07:00-19:00; We 07:00-19:00",
-        "title": "Coronatest Blisse",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3302237556941,
-          52.4806987949982
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Tübinger Str. 2, 10715 Berlin",
-        "telephone": null,
-        "details_url": "https://wirtesten.online/tuebingerstr",
-        "opening_hours": "Fr 06:00-22:00; Mo 06:00-22:00; Su 06:00-22:00; Tu 06:00-22:00; Sa 06:00-22:00; Th 06:00-22:00; We 06:00-22:00",
-        "title": "Test-To-Go Tübinger Straße 2",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.4938244115175,
           52.5088561597713
         ],
@@ -21733,75 +19577,6 @@
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3801,
-          52.45603
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Friedrich-Karl-Straße 21, 12103 Berlin",
-        "telephone": "015124313640",
-        "details_url": null,
-        "opening_hours": "Fr 10:00-20:00; Mo 08:00-18:00; Su 10:00-20:00; Tu 08:00-18:00; Sa 10:00-20:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "M.K.Test",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.48507,
-          52.46394
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Baumschulenstraße 77, 12437 Berlin",
-        "telephone": "030- 984 300 35",
-        "details_url": null,
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 12:00-16:00; Tu 07:00-20:00; Sa 10:00-18:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Teststation - Baume",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3442339460285,
-          52.439345186167
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Leonoren Str. 67 – 69, 12247 Berlin",
-        "telephone": "0177-8917868",
-        "details_url": "https://www.schnelltest-in-berlin.de",
-        "opening_hours": "Fr 07:00-21:30; Mo 07:00-21:30; Su 08:00-21:00; Tu 07:00-21:30; Sa 07:00-22:00; Th 07:00-21:30; We 07:00-21:30",
-        "title": "Testzentrum Leonoren Str. 67 am S-Bhf. Lankwitz",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
           "Terminbuchung: nicht notwendig"
         ]
       },
@@ -21856,22 +19631,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.316516655695,
-          52.5061290094751
+          13.3442339460285,
+          52.439345186167
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Kantstrasse 134b, 10625 Berlin",
-        "telephone": null,
-        "details_url": "https://www.kant-teststation.de",
-        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 08:00-19:00; Tu 08:00-19:00; Sa 08:00-19:00; Th 08:00-19:00; We 08:00-19:00",
-        "title": "Kant-Teststation",
+        "location": "Leonoren Str. 67 – 69, 12247 Berlin",
+        "telephone": "0177-8917868",
+        "details_url": "https://www.schnelltest-in-berlin.de",
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 10:00-16:00; Tu 08:00-18:00; Sa 10:00-16:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "Testzentrum Leonoren Str. 67 am S-Bhf. Lankwitz",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -21879,22 +19654,22 @@
     {
       "geometry": {
         "coordinates": [
-          13.289287753851,
-          52.6324573051971
+          13.48507,
+          52.46394
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Ludolfiger Platz 1, 13465 Berlin",
-        "telephone": null,
+        "location": "Baumschulenstraße 77, 12437 Berlin",
+        "telephone": "030- 984 300 35",
         "details_url": null,
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 08:00-20:00; Tu 07:00-20:00; Sa 08:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Teststation - Nord 2",
+        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 12:00-16:00; Tu 07:00-20:00; Sa 10:00-18:00; Th 07:00-20:00; We 07:00-20:00",
+        "title": "Teststation - Baume",
         "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -21925,75 +19700,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3008199403532,
-          52.5116260306819
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Bismarckstraße 59, 10627 Berlin",
-        "telephone": null,
-        "details_url": "https://www.covid19-test-berlin.de",
-        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 09:00-18:00; Tu 08:00-19:00; Sa 09:00-18:00; Th 08:00-19:00; We 08:00-19:00",
-        "title": "Covid19 Test Berlin",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.4985951710395,
-          52.5703909802503
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Ribnitzer Str. 15, 13051 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 08:00-19:00; Tu 08:00-19:00; Sa 08:00-19:00; Th 08:00-19:00; We 08:00-19:00",
-        "title": "Mima Test 15 Lichtenberg",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.522645,
-          52.497773
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Am Tierpark 69, 10319 Berlin",
-        "telephone": "01731601124",
-        "details_url": "https://www.event-coronatest.de",
-        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 09:00-19:00; Tu 07:00-19:00; Sa 09:00-20:00; Th 07:00-19:00; We 07:00-19:00",
-        "title": "Event Coronatest Tierpark",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.46756,
           52.55573
         ],
@@ -22010,29 +19716,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.4973314250128,
-          52.5611057244182
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Hansastr. 235, 13051 Berlin",
-        "telephone": null,
-        "details_url": "https://coronatest-hansastrasse.de",
-        "opening_hours": "Fr 07:30-20:00; Mo 07:30-20:00; Su 07:30-20:00; Tu 07:30-20:00; Sa 07:30-20:00; Th 07:30-20:00; We 07:30-20:00",
-        "title": "CORONATEST Hansastrasse",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -22074,6 +19757,75 @@
         "details_url": null,
         "opening_hours": "Fr 09:00-22:00; Mo 09:00-22:00; Su 09:00-22:00; Tu 09:00-22:00; Sa 09:00-22:00; Th 09:00-22:00; We 09:00-22:00",
         "title": "S.R Mobile Test Station",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.522645,
+          52.497773
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Am Tierpark 69, 10319 Berlin",
+        "telephone": "01731601124",
+        "details_url": "https://www.event-coronatest.de",
+        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 09:00-19:00; Tu 07:00-19:00; Sa 09:00-20:00; Th 07:00-19:00; We 07:00-19:00",
+        "title": "Event Coronatest Tierpark",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4973314250128,
+          52.5611057244182
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Hansastr. 235, 13051 Berlin",
+        "telephone": null,
+        "details_url": "https://coronatest-hansastrasse.de",
+        "opening_hours": "Fr 07:30-20:00; Mo 07:30-20:00; Su 07:30-20:00; Tu 07:30-20:00; Sa 07:30-20:00; Th 07:30-20:00; We 07:30-20:00",
+        "title": "CORONATEST Hansastrasse",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4985951710395,
+          52.5703909802503
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Ribnitzer Str. 15, 13051 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 08:00-19:00; Tu 08:00-19:00; Sa 08:00-19:00; Th 08:00-19:00; We 08:00-19:00",
+        "title": "Mima Test 15 Lichtenberg",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
@@ -22132,29 +19884,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.1975638832316,
-          52.5217742132481
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Pichelsdorfer Str. 77, 13595 Berlin",
-        "telephone": "030 629 307 3-00",
-        "details_url": "https://dieteststation.de/standort-spandau-pichelsdorfer-strasse",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "dieTeststation - Spandau / Pichelsdorfer Str.",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.58758,
           52.5215
         ],
@@ -22166,29 +19895,6 @@
         "details_url": "https://dieteststation.de",
         "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
         "title": "dieTeststation - Spree Center / U Kaulsdorf Nord",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.38582,
-          52.55798
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Prinzenallee 33, 13359 Berlin",
-        "telephone": "+491632828830",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Testzentrum Theater28",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
@@ -22247,6 +19953,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.38582,
+          52.55798
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Prinzenallee 33, 13359 Berlin",
+        "telephone": "+491632828830",
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-18:00; Tu 08:00-20:00; Sa 10:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Testzentrum Theater28",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.32915,
           52.46577
         ],
@@ -22286,167 +20015,6 @@
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3210779403528,
-          52.501219620414
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Knesebeckstr. 42, 10719 Berlin",
-        "telephone": null,
-        "details_url": "https://www.knese-testen.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-20:00; Tu 08:00-20:00; Sa 10:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Knese-Testen",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2403400980254,
-          52.5435883758802
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Gartenfelder Straße 90, 13599 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 08:00-19:00; Tu 08:00-19:00; Sa 08:00-19:00; Th 08:00-19:00; We 08:00-19:00",
-        "title": "City Teststelle",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3347227826812,
-          52.4882457078886
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Berliner Str. 4, 10715 Berlin",
-        "telephone": null,
-        "details_url": "https://www.coronateststation-ifa.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "IFA Corona Teststation",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.45198,
-          52.50841
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Revaler Straße 99, 10245 Berlin",
-        "telephone": null,
-        "details_url": "https://www.coronatest.de",
-        "opening_hours": "Fr 10:00-20:00; Mo 10:00-18:00; Su 10:00-18:00; Tu 10:00-18:00; Sa 10:00-20:00; Th 10:00-18:00; We 10:00-18:00",
-        "title": "(04) 10245 Coronatest.de S/U Warschauer Str. (Vor dem Suicide Circus)",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2617351936882,
-          52.5172666085219
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Steubenplatz 3-5, 14050 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 10:00-19:00; Tu 07:00-22:00; Sa 07:00-22:00; Th 07:00-22:00; We 07:00-22:00",
-        "title": "T.J Firstclass Teststation",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.32831,
-          52.47044
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Bundesallee 78, 12161 Berlin",
-        "telephone": null,
-        "details_url": "https://www.covidzentrum.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "(06) Covidzentrum Friedenau",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13,
-          52.5388057184995
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Zeppelinstr.55, 13583 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "CK Corona Testzentrum",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -22500,17 +20068,17 @@
     {
       "geometry": {
         "coordinates": [
-          13.2907623115176,
-          52.5110017733476
+          13.45198,
+          52.50841
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Kaiserdamm 8, 14057 Berlin",
-        "telephone": "030-30103210",
-        "details_url": null,
-        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Su 09:00-20:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
-        "title": "Kosmetik Jungbrunnen",
+        "location": "Revaler Straße 99, 10245 Berlin",
+        "telephone": null,
+        "details_url": "https://www.coronatest.de",
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-18:00; Su 10:00-18:00; Tu 10:00-18:00; Sa 10:00-20:00; Th 10:00-18:00; We 10:00-18:00",
+        "title": "10245 Coronatest.de S/U Warschauer Str. (Vor dem Suicide Circus)",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: keine Angabe",
@@ -22523,17 +20091,63 @@
     {
       "geometry": {
         "coordinates": [
-          13,
-          52.5103221349437
+          13.32831,
+          52.47044
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Wilmersdorfer Straße 128, 10627 Berlin",
+        "location": "Bundesallee 78, 12161 Berlin",
+        "telephone": null,
+        "details_url": "https://www.covidzentrum.de",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Covidzentrum Friedenau",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.1822940270547,
+          52.5388057184968
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Zeppelinstr.55, 13583 Berlin",
         "telephone": null,
         "details_url": null,
-        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Su 10:00-18:00; Tu 09:00-19:00; Sa 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
-        "title": "testfabrik24",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "CK Corona Testzentrum",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.2403400980254,
+          52.5435883758802
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Gartenfelder Straße 90, 13599 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 08:00-19:00; Tu 08:00-19:00; Sa 08:00-19:00; Th 08:00-19:00; We 08:00-19:00",
+        "title": "City Teststelle",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
@@ -22569,29 +20183,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3069118710371,
-          52.5040928624995
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Mommsenstraße 31, 10629 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 08:00-22:00; Mo 08:00-20:00; Su 10:00-18:00; Tu 08:00-20:00; Sa 08:00-22:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "MommsenTest 31",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.36699,
           52.55172
         ],
@@ -22605,55 +20196,9 @@
         "title": "C und C Testzentrum",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
+          "Barrierefreiheit: ja",
           "Tests für Kinder: ja",
           "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.5157675845325,
-          52.5579217338854
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Wartenberger Straße 102A, 13053 Berlin",
-        "telephone": null,
-        "details_url": "https://www.testedichschnell.de",
-        "opening_hours": "Fr 06:00-20:00; Mo 06:00-20:00; Su 06:00-20:00; Tu 06:00-20:00; Sa 06:00-20:00; Th 06:00-20:00; We 06:00-20:00",
-        "title": "Test2Go Wartenberger Straße 102A",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3205528,
-          52.4793293
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Blissestr.65, 10713 Berlin",
-        "telephone": "0176 804 88 66 5",
-        "details_url": "https://blisse.teststation-to-go.de",
-        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 10:00-19:00; Tu 08:00-19:00; Sa 10:00-19:00; Th 08:00-19:00; We 08:00-19:00",
-        "title": "Teststation Blisse",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -22698,6 +20243,75 @@
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3059567270536,
+          52.510322134941
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Wilmersdorfer Straße 128, 10627 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Su 10:00-18:00; Tu 09:00-19:00; Sa 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
+        "title": "testfabrik24",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3069118710371,
+          52.5040928624995
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Mommsenstraße 31, 10629 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-22:00; Mo 08:00-20:00; Su 10:00-18:00; Tu 08:00-20:00; Sa 08:00-22:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "MommsenTest 31",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.5157675845325,
+          52.5579217338854
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Wartenberger Straße 102A, 13053 Berlin",
+        "telephone": null,
+        "details_url": "https://www.testedichschnell.de",
+        "opening_hours": "Fr 06:00-20:00; Mo 06:00-20:00; Su 06:00-20:00; Tu 06:00-20:00; Sa 06:00-20:00; Th 06:00-20:00; We 06:00-20:00",
+        "title": "Test2Go Wartenberger Straße 102A",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
@@ -22785,7 +20399,7 @@
       "properties": {
         "location": "Klemkestr. 1, 13409 Berlin",
         "telephone": "030 / 98452088",
-        "details_url": null,
+        "details_url": "http://www.testzentrum-klemke.de",
         "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 09:00-18:00; Tu 07:00-22:00; Sa 08:00-22:00; Th 07:00-22:00; We 07:00-22:00",
         "title": "TESTZENTRUM KLEMKE",
         "hints": [
@@ -22793,190 +20407,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: ja",
           "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3663454,
-          52.6042682
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Quickborner Straße 76, 13439 Berlin",
-        "telephone": "017661066378",
-        "details_url": null,
-        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Su 09:00-18:00; Tu 09:00-18:00; Sa 09:00-18:00; Th 09:00-18:00; We 09:00-18:00",
-        "title": "Teststation Quickborner",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3203770826819,
-          52.5067413647372
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Bleibtreustraße 52, 10623 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 06:00-20:00; Mo 06:00-20:00; Su 06:00-20:00; Tu 06:00-20:00; Sa 06:00-20:00; Th 06:00-20:00; We 06:00-20:00",
-        "title": "Testzentrum PT Berlin 3",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2913822115163,
-          52.4752781894466
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Breite Straße 26, 14199 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 06:30-19:00; Mo 06:30-19:00; Su 06:30-19:00; Tu 06:30-19:00; Sa 06:30-19:00; Th 06:30-19:00; We 06:30-19:00",
-        "title": "Testzentrum PT Berlin",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2909235268599,
-          52.5167094717478
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Christstraße 32, 14059 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 07:00-19:00; Tu 07:00-19:00; Sa 07:00-19:00; Th 07:00-19:00; We 07:00-19:00",
-        "title": "Testzentrum PT Berlin 2",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2921901115174,
-          52.5071208967433
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Neue Kantstrasse 5, 14057 Berlin",
-        "telephone": null,
-        "details_url": "http://www.myberlintest.de",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "My Berlin Test",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.28741,
-          52.45791
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Königen-Luise-Str. 54, 14195 Berlin",
-        "telephone": "015735839570",
-        "details_url": null,
-        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Su 09:00-20:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
-        "title": "KommMitTeststation 2",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3153988226121,
-          52.5757970813274
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Eichborndamm 84, 13403 Berlin",
-        "telephone": "030 / 666 222 87",
-        "details_url": "https://www.gut8en.berlin",
-        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Su 09:00-19:00; Tu 09:00-19:00; Sa 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
-        "title": "Testzentrum Gut8en.Berlin",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2995290556944,
-          52.4893458351255
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Hohenzollerndamm 48, 10713 Berlin",
-        "telephone": null,
-        "details_url": "https://www.mycoronatest.berlin",
-        "opening_hours": "Fr 08:00-21:00; Mo 08:00-21:00; Su 11:00-19:00; Tu 08:00-21:00; Sa 08:00-21:00; Th 08:00-21:00; We 08:00-21:00",
-        "title": "MyCoronaTest – Wilmersdorf",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -23017,7 +20447,7 @@
         "telephone": null,
         "details_url": "https://www.mycoronatest.berlin",
         "opening_hours": "Fr 10:00-22:00; Mo 10:00-21:00; Tu 10:00-21:00; Sa 10:00-22:00; Th 10:00-21:00; We 10:00-21:00",
-        "title": "(1111) myCoronatest Knaack Str.",
+        "title": "myCoronatest Knaack Str.",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -23053,29 +20483,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3052499556951,
-          52.5071279151205
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Kantstraße 59, 10623 Berlin",
-        "telephone": null,
-        "details_url": "https://www.mycoronatest.berlin",
-        "opening_hours": "Fr 08:00-21:00; Mo 08:00-21:00; Su 11:00-19:00; Tu 08:00-21:00; Sa 08:00-21:00; Th 08:00-21:00; We 08:00-21:00",
-        "title": "MyCoronaTest – Charlottenburg 2",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.3074814654938,
           52.5793505701623
         ],
@@ -23092,98 +20499,6 @@
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: ja",
           "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.10397,
-          52.33026
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Westerwaldstraße 13 Ecke Hermann-Schmidt-Weg, 13589 Berlin",
-        "telephone": "015163622230",
-        "details_url": "https:////schnelltesten.digital/KD-corona-Testzentrum",
-        "opening_hours": "Fr 06:00-20:00; Mo 06:00-20:00; Su 06:00-20:00; Tu 06:00-20:00; Sa 06:00-20:00; Th 06:00-20:00; We 06:00-20:00",
-        "title": "KD Corona Test",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.607433740354,
-          52.5354010226585
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Heidenauer Str. 26, 12627 Berlin",
-        "telephone": null,
-        "details_url": "https://www.kostenloser-schnelltest-berlin.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Elixia Vitalclub",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3277088115196,
-          52.5647135439255
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Scharnweberstr .17, 13405 Berlin",
-        "telephone": "017683059643",
-        "details_url": null,
-        "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 07:00-22:00; Tu 07:00-22:00; Sa 07:00-22:00; Th 07:00-22:00; We 07:00-22:00",
-        "title": "Teststation kutschi",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.41173,
-          52.56873
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Berliner Straße 11, 13187 Berlin",
-        "telephone": "+491632997118",
-        "details_url": "https://www.aktivtel.de",
-        "opening_hours": "Fr 09:00-23:00; Mo 09:00-23:00; Su 09:00-23:00; Tu 09:00-23:00; Sa 09:00-23:00; Th 09:00-23:00; We 09:00-23:00",
-        "title": "Krasimir Berliner Str.",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -23214,29 +20529,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3707845100782,
-          52.501055071735
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Flottwellstraße 14, 10785 Berlin",
-        "telephone": "015788844144",
-        "details_url": "http://www.teststation-gleisdreieck.de",
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Teststation am Gleisdreieck",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.1785402003013,
           52.5180681241825
         ],
@@ -23248,29 +20540,6 @@
         "details_url": "http://www.intermedicaltestcenter.de",
         "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Tu 07:00-21:00; Sa 07:00-21:00; Th 07:00-21:00; We 07:00-21:00",
         "title": "Testzentrum ALDI Heerstr. 332",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2090691254268,
-          52.5570437593367
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Streitstr. 5-19, 13587 Berlin",
-        "telephone": "01520 3873038",
-        "details_url": "http://www.intermedicaltestcenter.de",
-        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Tu 07:00-21:00; Sa 07:00-21:00; Th 07:00-21:00; We 07:00-21:00",
-        "title": "Testzentrum ALDI Streitstr. 5-19",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
@@ -23352,6 +20621,52 @@
     {
       "geometry": {
         "coordinates": [
+          13.607433740354,
+          52.5354010226585
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Heidenauer Str. 26, 12627 Berlin",
+        "telephone": null,
+        "details_url": "https://www.kostenloser-schnelltest-berlin.de",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Elixia Vitalclub",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3277088115196,
+          52.5647135439255
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Scharnweberstr .17, 13405 Berlin",
+        "telephone": "017683059643",
+        "details_url": null,
+        "opening_hours": "Fr 08:00-18:00; Mo 07:00-18:00; Su 10:00-18:00; Tu 08:00-18:00; Sa 10:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "Teststation kutschi",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.2377865407721,
           52.527276343156
         ],
@@ -23368,29 +20683,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.4832136120222,
-          52.6123943151532
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Alt-Karow 8, 13125 Berlin",
-        "telephone": "017660499632",
-        "details_url": "http://www.testzentrumaltkarow.de",
-        "opening_hours": "Fr 09:00-15:00, 18:30-20:00; Mo 09:00-15:00, 18:30-20:00; Su 14:00-18:00; Tu 09:00-15:00, 18:30-20:00; Th 09:00-15:00, 18:30-20:00; We 09:00-15:00, 18:30-20:00",
-        "title": "Testzentrum Alt-Karow",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -23513,29 +20805,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3385767983477,
-          52.5295137183315
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Bremerstraße 11, 10551 Berlin",
-        "telephone": "017643472661/ 017657696360",
-        "details_url": "https://Test-mich-testzentrum.webnode.page",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 09:00-17:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Test Mich",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.3369099,
           52.5248423
         ],
@@ -23552,29 +20821,6 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: ja",
           "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.4067989829849,
-          52.5259472289337
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Alte Schönhauserstr. 25, 10119 Berlin",
-        "telephone": "01633508410",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Testzentrum Aykut",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -23628,29 +20874,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.28956,
-          52.5812
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Egellsstr. 12, 13507 Berlin",
-        "telephone": "+49 176 75271980",
-        "details_url": "https://www.border-point.de",
-        "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 07:00-22:00; Tu 07:00-22:00; Sa 07:00-22:00; Th 07:00-22:00; We 07:00-22:00",
-        "title": "Corona Border Point GmbH",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.35093,
           52.57041
         ],
@@ -23661,35 +20884,12 @@
         "telephone": "+49 176 75271980",
         "details_url": "https://www.border-point.de",
         "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Su 09:00-18:00; Tu 09:00-18:00; Sa 09:00-18:00; Th 09:00-18:00; We 09:00-18:00",
-        "title": "Corona Border Point GmbH",
+        "title": "Corona Border Point",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: keine Angabe",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.4258688982204,
-          52.5784733514036
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Achtermann Str. 21, 13187 Berlin",
-        "telephone": "01632644428",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Testzentrum Pankow Heinersdorf Vesaliusstr.",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -23720,6 +20920,29 @@
     {
       "geometry": {
         "coordinates": [
+          13.370118,
+          52.542294
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Reinickendorfer Str. 12, 13347 Berlin",
+        "telephone": "017680119229",
+        "details_url": "https://wedding.quicktest2go.de",
+        "opening_hours": "Fr 08:00-19:30; Mo 08:00-19:30; Su 10:00-18:00; Tu 08:00-19:30; Sa 09:00-19:00; Th 08:00-19:30; We 08:00-19:30",
+        "title": "Quick Test",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
           13.4617669558911,
           52.5510607204343
         ],
@@ -23743,21 +20966,44 @@
     {
       "geometry": {
         "coordinates": [
-          13.370118,
-          52.542294
+          13.28956,
+          52.5812
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Reinickendorfer Str. 12, 13347 Berlin",
-        "telephone": "017680119229",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-19:30; Mo 08:00-19:30; Su 10:00-18:00; Tu 08:00-19:30; Sa 09:00-18:00; Th 08:00-19:30; We 08:00-19:30",
-        "title": "Quick Test",
+        "location": "Egellsstraße 12, 13507 Berlin",
+        "telephone": "+49 176 75271980",
+        "details_url": "https://www.border-point.de",
+        "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 07:00-22:00; Tu 07:00-22:00; Sa 07:00-22:00; Th 07:00-22:00; We 07:00-22:00",
+        "title": "Corona Border Point",
         "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4257830675333,
+          52.5784929103116
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Achtermannstraße 21, 13187 Berlin",
+        "telephone": "01632644428",
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Testzentrum Pankow Heinersdorf Vesaliusstr.",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
         ]
       },
@@ -23858,29 +21104,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.5257385963653,
-          52.4819961255213
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Treskowallee 109, 10318 Berlin",
-        "telephone": null,
-        "details_url": "https://www.coronapoint.de",
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Coronapoint Berlin-Lichtenberg",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.27983,
           52.5183
         ],
@@ -23892,121 +21115,6 @@
         "details_url": null,
         "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 09:00-20:00; Tu 08:00-20:00; Sa 09:00-20:00; Th 08:00-20:00; We 08:00-20:00",
         "title": "Testzentrum Westend",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3187969828739,
-          52.5063553871508
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Kantstraße 28, 10623 Berlin",
-        "telephone": null,
-        "details_url": "http://www.mycoronatest.berlin",
-        "opening_hours": "Fr 08:00-21:00; Mo 08:00-21:00; Su 11:00-19:00; Tu 08:00-21:00; Sa 08:00-21:00; Th 08:00-21:00; We 08:00-21:00",
-        "title": "MyCoronaTest – Charlottenburg",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.4150631712349,
-          52.5560036775904
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Berliner Str. 80, 13189 Berlin",
-        "telephone": "030994049907",
-        "details_url": "http://sofort.coronatest.de",
-        "opening_hours": "Fr 08:00-17:00; Mo 08:00-17:00; Tu 08:00-17:00; Th 08:00-17:00; We 08:00-17:00",
-        "title": "Testcenter-Pankow, U2 Vinetastr.",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2929159963666,
-          52.5136585826243
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Knobelsdorffstraße 24, 14059 Berlin",
-        "telephone": null,
-        "details_url": "https://www.berlinertestzentrum.de/impressum",
-        "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 07:00-18:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
-        "title": "AMP Testzentrum",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3219,
-          52.4565
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Albrechtstr. 3, 12165 Berlin",
-        "telephone": "017675271980",
-        "details_url": "http://www.border-point.de",
-        "opening_hours": "Fr 00:00-23:59; Mo 00:00-23:59; Su 00:00-23:59; Tu 00:00-23:59; Sa 00:00-23:59; Th 00:00-23:59; We 00:00-23:59",
-        "title": "Corona Border Point GmbH",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3046752252026,
-          52.5178956961813
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Otto-Suhr-Allee 121, 10585 Berlin",
-        "telephone": null,
-        "details_url": "https://www.Otto.Covid19-Berlin.de",
-        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
-        "title": "Covid-19 Testzentrum",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
@@ -24042,29 +21150,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.4069293847265,
-          52.5400391631637
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Oderbergerstr. 23, 10435 Berlin",
-        "telephone": "+49151 71 331 350",
-        "details_url": "https://norona-berlin.covidservicepoint.de",
-        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
-        "title": "Norona-Mauerpark",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.3667143,
           52.5500701
         ],
@@ -24088,21 +21173,21 @@
     {
       "geometry": {
         "coordinates": [
-          13.433283,
-          52.482174
+          13.55488,
+          52.51384
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Karl-Marx-Str. 144, 12043 Berlin",
-        "telephone": "030848586894",
-        "details_url": "https://www.flash-testzentrum.de",
-        "opening_hours": "Fr 10:00-18:00; Mo 10:00-18:00; Tu 10:00-18:00; Sa 10:00-18:00; Th 10:00-18:00; We 10:00-18:00",
-        "title": "Flash-Testzentrum",
+        "location": "Oberfeldstr. 197, 12683 Berlin",
+        "telephone": null,
+        "details_url": "http://www.border-point.de",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Corona Border Point",
         "hints": [
           "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
+          "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
       },
@@ -24127,6 +21212,29 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4069293847265,
+          52.5400391631637
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Oderberger Str. 23, 10435 Berlin",
+        "telephone": "+49151 71 331 350",
+        "details_url": "https://norona-berlin.covidservicepoint.de",
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "Norona-Mauerpark",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
         ]
       },
       "type": "Feature"
@@ -24203,29 +21311,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3848995982194,
-          52.5522442628132
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Stettiner Straße 5, 13357 Berlin",
-        "telephone": null,
-        "details_url": null,
-        "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 07:00-18:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
-        "title": "Stettiner-Station",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.459089,
           52.439562
         ],
@@ -24239,29 +21324,6 @@
         "title": "CORONA TESTZENTRUM RUDOW",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.26132,
-          52.43723
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Clayallee 335, 14169 Berlin",
-        "telephone": "030 60 989 55 01",
-        "details_url": "http://www.covidzentrum.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "CovidZentrum Zehlendorf",
-        "hints": [
-          "PCR-Nachtestung: ja",
           "Barrierefreiheit: ja",
           "Tests für Kinder: ja",
           "Terminbuchung: optional"
@@ -24318,29 +21380,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3849505,
-          52.5502348
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Badstraße 67, 13357 Berlin",
-        "telephone": "03046112713",
-        "details_url": "https://www.flash-testzentrum.de",
-        "opening_hours": "Fr 10:00-18:00; Mo 10:00-18:00; Tu 10:00-18:00; Sa 10:00-18:00; Th 10:00-18:00; We 10:00-18:00",
-        "title": "Flash-Testzentrum",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.34412,
           52.55556
         ],
@@ -24364,88 +21403,19 @@
     {
       "geometry": {
         "coordinates": [
-          13.4037985873707,
-          52.5201220597243
+          13.3849505,
+          52.5502348
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Spandauer Str. 3, 10178 Berlin",
-        "telephone": null,
-        "details_url": "https://www.testzentrum-am-alex.de",
-        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
-        "title": "Testzentrum Am Alex",
+        "location": "Badstraße 67, 13357 Berlin",
+        "telephone": "03046112713",
+        "details_url": "https://www.flash-testzentrum.de",
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "Flash-Testzentrum",
         "hints": [
           "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.2410948270549,
-          52.5435009033923
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Gartenfelderstr. 84, 13599 Berlin",
-        "telephone": "01634548674",
-        "details_url": null,
-        "opening_hours": "Fr 08:00-21:00; Mo 08:00-21:00; Su 08:00-18:00; Tu 08:00-21:00; Sa 08:00-18:00; Th 08:00-21:00; We 08:00-21:00",
-        "title": "Smart Testzentrum",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3355579540415,
-          52.5928638299656
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Roedernallee 80, 13437 Berlin",
-        "telephone": "030/24379057",
-        "details_url": "https://test@baerliner-sperrmuell-recycling.de",
-        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 08:00-19:00; Tu 08:00-19:00; Sa 08:00-19:00; Th 08:00-19:00; We 08:00-19:00",
-        "title": "Teststelle Wittenau",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.49107,
-          52.49262
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Hauptstr. 13, 10317 Berlin",
-        "telephone": null,
-        "details_url": "https://www.schnelltests-berlin.com",
-        "opening_hours": "Fr 10:00-18:00; Mo 10:00-18:00; Su 10:00-18:00; Tu 10:00-18:00; Sa 10:00-18:00; Th 10:00-18:00; We 10:00-18:00",
-        "title": "BG Ostbloc",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: ja",
           "Terminbuchung: nicht notwendig"
@@ -24479,29 +21449,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.3149179,
-          52.4726321
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Rüdesheimer Platz 7, 14197 Berlin",
-        "telephone": "+4917662707061",
-        "details_url": "https://www.schnelltests-berlin.com",
-        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Su 09:00-18:00; Tu 09:00-18:00; Sa 09:00-18:00; Th 09:00-18:00; We 09:00-18:00",
-        "title": "BG Rüdesheimer",
-        "hints": [
-          "PCR-Nachtestung: keine Angabe",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: keine Angabe",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.34608,
           52.54757
         ],
@@ -24526,52 +21473,6 @@
     {
       "geometry": {
         "coordinates": [
-          13.34522,
-          52.52738
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Lübecker Straße 48, 10559 Berlin",
-        "telephone": "01639492229",
-        "details_url": null,
-        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
-        "title": "Moas Testzentrum",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: keine Angabe",
-          "Tests für Kinder: ja",
-          "Terminbuchung: nicht notwendig"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          13.3966720540393,
-          52.5378883448229
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "location": "Brunnenstr. 47, 10115 Berlin",
-        "telephone": null,
-        "details_url": "https://www.pcrpoint.de",
-        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Su 10:00-16:00; Tu 09:00-18:00; Sa 10:00-16:00; Th 09:00-18:00; We 09:00-18:00",
-        "title": "PCR Point",
-        "hints": [
-          "PCR-Nachtestung: ja",
-          "Barrierefreiheit: ja",
-          "Tests für Kinder: ja",
-          "Terminbuchung: optional"
-        ]
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           13.2874048982206,
           52.5837101760716
         ],
@@ -24588,6 +21489,52 @@
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3355579540415,
+          52.5928638299656
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Roedernallee 80, 13437 Berlin",
+        "telephone": "030/24379057",
+        "details_url": "https://test@baerliner-sperrmuell-recycling.de",
+        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 08:00-19:00; Tu 08:00-19:00; Sa 08:00-19:00; Th 08:00-19:00; We 08:00-19:00",
+        "title": "Teststelle Wittenau",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.34522,
+          52.52738
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Lübecker Straße 48, 10559 Berlin",
+        "telephone": "01639492229",
+        "details_url": null,
+        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
+        "title": "Moas Testzentrum",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
         ]
       },
       "type": "Feature"
@@ -24641,23 +21588,2008 @@
     {
       "geometry": {
         "coordinates": [
-          13.3491307,
-          52.5264497
+          13.4418328873924,
+          52.4738243326428
         ],
         "type": "Point"
       },
       "properties": {
-        "location": "Turmstr. 18, 10559 Berlin",
-        "telephone": "+4917662707061",
-        "details_url": "https://www.schnelltests-berlin.com",
-        "opening_hours": "Fr 08:00-17:00; Mo 08:00-17:00; Su 08:00-17:00; Tu 08:00-17:00; Sa 08:00-17:00; Th 08:00-17:00; We 08:00-17:00",
-        "title": "BG Turmstraße",
+        "location": "Karl-Marx-Platz, 12043 Berlin",
+        "telephone": null,
+        "details_url": "https://testenberlinneukoelln.de",
+        "opening_hours": "Fr 06:30-20:00; Mo 06:30-20:00; Su 06:30-20:00; Tu 06:30-20:00; Sa 06:30-20:00; Th 06:30-20:00; We 06:30-20:00",
+        "title": "Testen Berlin Neukölln",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4532873005664,
+          52.4295042326807
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "U Johannisthaler Chaussee, 12351 Berlin",
+        "telephone": null,
+        "details_url": "https://testenberlinneukoelln.de",
+        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
+        "title": "Testen Berlin Neukölln",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4952965407402,
+          52.416327212696
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "U Rudow/Neuköllner  Str./Groß-Ziethener CH, 12357 Berlin",
+        "telephone": null,
+        "details_url": "https://testenberlinneukoelln.de",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Testen Berlin Neukölln",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4420768558878,
+          52.4695866605347
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "S+U Neukölln/Karl-Marx-Str., 12055 Berlin",
+        "telephone": null,
+        "details_url": "https://testenberlinneukoelln.de",
+        "opening_hours": "Fr 06:30-20:00; Mo 06:30-20:00; Su 06:30-20:00; Tu 06:30-20:00; Sa 06:30-20:00; Th 06:30-20:00; We 06:30-20:00",
+        "title": "Testen Berlin Neukölln",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.412719,
+          52.519172
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Spandauerstr. 4, 10178 Berlin",
+        "telephone": "030 97 00 46 60",
+        "details_url": null,
+        "opening_hours": "Fr 07:00-23:00; Mo 07:00-23:00; Su 07:00-23:00; Tu 07:00-23:00; Sa 07:00-00:00; Th 07:00-23:00; We 07:00-23:00",
+        "title": "KD Testzentrum",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4484395693808,
+          52.4856300490927
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Harzerstr. 87, 12059 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 10:00-18:00; Tu 08:00-18:00; Sa 10:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "Test2GO-Timeless",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.57599,
+          52.45434
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Bahnhofstraße 5, 12555 Berlin",
+        "telephone": "+491716444431",
+        "details_url": "https://pyrothron.com",
+        "opening_hours": "Fr 09:00-18:00; Mo 09:00-18:00; Tu 09:00-18:00; Sa 09:00-13:00; Th 09:00-18:00; We 09:00-18:00",
+        "title": "Corona Teststation Thron Pyro GmbH",
         "hints": [
           "PCR-Nachtestung: keine Angabe",
           "Barrierefreiheit: ja",
           "Tests für Kinder: keine Angabe",
           "Terminbuchung: optional"
         ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.62538,
+          52.45609
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Bölschestraße 67, 12587 Berlin",
+        "telephone": null,
+        "details_url": "https://peggymeyer.schnelltest2go.berlin",
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 10:00-15:00; Tu 08:00-18:00; Sa 09:30-16:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "Schnelltest 2 go Berlin - Peggy Meyer",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.1774961135628,
+          52.5507759691429
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Westerwaldstraße 13, 13589 Berlin",
+        "telephone": "+4915163622230",
+        "details_url": "https://schnelltesten.digital/KD-corona-Testzentrum",
+        "opening_hours": "Fr 06:00-20:00; Mo 06:00-20:00; Su 10:00-20:00; Tu 06:00-20:00; Sa 10:00-20:00; Th 06:00-20:00; We 06:00-20:00",
+        "title": "KD Corona Test",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4980699982179,
+          52.5147870912212
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Siegfriedstr. 203, 10365 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Su 09:00-20:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
+        "title": "CC Teststation",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.35306,
+          52.5499
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Müllerstraße 40, 13353 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 11:00-18:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "müller Corona Testzentrum",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4339235828713,
+          52.4403581036944
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Buckower Damm 50, 12349 Berlin",
+        "telephone": "01520 3873038",
+        "details_url": "http://www.intermedicaltestcenter.de",
+        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Tu 07:00-21:00; Sa 07:00-21:00; Th 07:00-21:00; We 07:00-21:00",
+        "title": "Testzentrum ALDI Buckower Damm 50",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3252313,
+          52.461445
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "U-Bahnhof Schloßstr., 12163 Berlin",
+        "telephone": null,
+        "details_url": "https://www.schnelltests-berlin.com",
+        "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 10:00-19:00; Tu 07:00-22:00; Sa 10:00-19:00; Th 07:00-22:00; We 07:00-22:00",
+        "title": "BG Schloßstraße",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.29,
+          52.458
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Königin-Luise-Str. 44, 14195 Berlin",
+        "telephone": "015157120582",
+        "details_url": "https://www.schnelltests-berlin.com",
+        "opening_hours": "Fr 07:30-16:30; Mo 07:30-16:30; Tu 07:30-16:30; Th 07:30-16:30; We 07:30-16:30",
+        "title": "DG Ristaurante Piaggio",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.243512,
+          52.614039
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schulzendorfer Straße 3, 13503 Berlin",
+        "telephone": "+49 176 2311 3476",
+        "details_url": null,
+        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 16:00-19:00; Tu 07:00-19:00; Sa 09:00-14:00; Th 07:00-19:00; We 07:00-19:00",
+        "title": "Teststation - Heiligensee",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.44447,
+          52.46799
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Rudower Straße 5, 12351 Berlin",
+        "telephone": "0176/72205552",
+        "details_url": "https://wirtesten.online/purus-curae-mobil1",
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "Corona Teststation Purus Curae Mobil1",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.278679,
+          52.449365
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Ihnestr. 16-20, 14195 Berlin",
+        "telephone": "015157120582",
+        "details_url": "https://www.schnelltests-berlin.com",
+        "opening_hours": "Fr 07:30-16:30; Mo 07:30-16:30; Tu 07:00-16:30; Th 07:30-16:30; We 07:30-16:30",
+        "title": "BG Harnack Haus",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.44447,
+          52.46799
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Lahnstraße 84, 12055 Berlin",
+        "telephone": null,
+        "details_url": "https://testen.berlin/purus-curae",
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "Corona Testzentrum purus curae",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3905,
+          52.5069
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Friedrichstraße 43-45, 10117 Berlin",
+        "telephone": null,
+        "details_url": "https://www.deinecoronatester.de",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Deine Coronatester Checkpoint Charlie",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.1310835135594,
+          52.4640048596238
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Ritterfelddamm 116, 14089 Berlin",
+        "telephone": "030-43772299",
+        "details_url": "https://Planung-ug.de",
+        "opening_hours": null,
+        "title": "Testzentrum-Kladow",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3175481982175,
+          52.5041300244707
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schlüterstraße 54, 10629 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "Schlütertest54",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3769977405452,
+          52.4911654628197
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Katzbachstraße 38, 10965 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 09:00-22:00; Tu 07:00-22:00; Sa 09:00-22:00; Th 07:00-22:00; We 07:00-22:00",
+        "title": "COVID-Teststation Orti",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.595802698218,
+          52.5197610608629
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Uckermarkstr. 86, 12621 Berlin",
+        "telephone": null,
+        "details_url": "https://www.berlintestedich.de",
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "BerlinTesteDich",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4025878405457,
+          52.5040522783243
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Ritterstr. 42, 10969 Berlin",
+        "telephone": "+49151 71 331 350",
+        "details_url": "https://norona-berlin.covidservicepoint.de",
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "Norona-Ritter",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.45394,
+          52.42974
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Johannisthaler Chaussee 326, 12351 Berlin",
+        "telephone": null,
+        "details_url": "https://event-coronatest.covidservicepoint.de",
+        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 08:00-19:00; Tu 08:00-19:00; Sa 08:00-19:00; Th 08:00-19:00; We 08:00-19:00",
+        "title": "Event-Coronatest Gropius Passagen",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.31377,
+          52.50552
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Leibnizstraße 68, 10625 Berlin",
+        "telephone": null,
+        "details_url": "https://www.testzentrum-leibniz.de",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Testzentrum-Leibniz",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3806214982175,
+          52.5049730971267
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Bernburger Straße 35, 10963 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Testcenter Ebs",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4746052804987,
+          52.4233763352384
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Rotraut-Richter Platz, 12353 Berlin",
+        "telephone": null,
+        "details_url": "http://www.testcenter-wutzkycenter.de",
+        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Tu 07:00-19:00; Sa 09:00-17:00; Th 07:00-19:00; We 07:00-19:00",
+        "title": "Teststation am Wutzkycenter",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4821974828744,
+          52.5165266569276
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Rudolf-Reusch Str. 17, 10367 Berlin",
+        "telephone": "01787481922",
+        "details_url": "https://www.teststelleamrathaus.de",
+        "opening_hours": "Fr 07:00-17:00; Mo 07:00-17:00; Su 09:00-15:00; Tu 07:00-17:00; Sa 09:00-15:00; Th 07:00-17:00; We 07:00-17:00",
+        "title": "Teststelle am Rathaus",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4618281270504,
+          52.4323042415803
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Johannisthaler Chaussee 261, 12351 Berlin",
+        "telephone": null,
+        "details_url": "https://hygnkonzept.digastro-software.de/terin-johannisthaler",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-20:00; Tu 08:00-20:00; Sa 10:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Test-To-Go Johannisthaler Chaussee",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4491186558882,
+          52.4791756055575
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Treptower Str. 90, 12059 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
+        "title": "BD Series Treptower Str",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.31691,
+          52.45869
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Grunewaldstraße 8-9, 12165 Berlin",
+        "telephone": "030/ 239 938 27",
+        "details_url": "http://www.teststation-orti.de",
+        "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 09:00-20:00; Tu 07:00-22:00; Sa 09:00-20:00; Th 07:00-22:00; We 07:00-22:00",
+        "title": "COVID-Teststation Orti",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4893444117107,
+          52.5275028332531
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Herzbergstr.128-139, 10365 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "Schnelltest-herzbergstr",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4217621828732,
+          52.4869529110994
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Hasenheide 108, 10967 Berlin",
+        "telephone": "01520 3873038",
+        "details_url": "http://www.intermedicaltestcenter.de",
+        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Su 07:00-21:00; Tu 07:00-21:00; Sa 07:00-21:00; Th 07:00-21:00; We 07:00-21:00",
+        "title": "Testzentrum ALDI Hasenheide 108",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.38289,
+          52.55408
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Prinzenallee 81, 13357 Berlin",
+        "telephone": "+493084514024",
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Testzentrum - Prinzenallee",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4399642135626,
+          52.5442052736768
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Erich-Weinert-Straße 139, 10409 Berlin",
+        "telephone": null,
+        "details_url": "https://covidschnelltestzentrum-medical.de",
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "COVID-Schnelltestzentrum",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.2456,
+          52.5786
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schwarzer Weg 95, 13505 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 09:00-17:00; Mo 09:00-17:00; Su 11:00-16:00; Tu 09:00-17:00; Sa 11:00-16:00; Th 09:00-17:00; We 09:00-17:00",
+        "title": "Strandbad Tegelsee",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.38002,
+          52.47826
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Erika-Gräfin-von-Brockdorff-Platz, 12101 Berlin",
+        "telephone": null,
+        "details_url": "https://coronatest.de",
+        "opening_hours": "Fr 06:00-20:00; Mo 06:00-20:00; Su 10:00-18:00; Tu 06:00-20:00; Sa 10:00-18:00; Th 06:00-20:00; We 06:00-20:00",
+        "title": "12101 Coronatest.de S/U Südkreuz",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4998068000713,
+          52.5718111371383
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Ribnitzer Str. 10a, 13051 Berlin",
+        "telephone": "01749609621",
+        "details_url": null,
+        "opening_hours": "Fr 08:00-19:00; Mo 08:00-19:00; Su 08:00-19:00; Tu 08:00-19:00; Sa 08:00-19:00; Th 08:00-19:00; We 08:00-19:00",
+        "title": "MiMa Test 15",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3966626828785,
+          52.6198580766555
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Hauptstr. 52, 13158 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": null,
+        "title": "Physiotherapie Wilhelmsruh",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: notwendig"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.2004435982192,
+          52.5487179539255
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Hügelschanze 29, 13585 Berlin",
+        "telephone": "0151 24933252",
+        "details_url": "https://www.testfast.de/book/testzentrum-hs",
+        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Su 10:00-18:00; Tu 09:00-19:00; Sa 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
+        "title": "Testzentrum HS",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.1765052405474,
+          52.5488687645712
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Falkenseer Chaussee 236, 13583 Berlin",
+        "telephone": "01799280582",
+        "details_url": null,
+        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 07:00-20:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
+        "title": "Falkenseer Chaussee 236",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3561475658069,
+          52.596765300159
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Wilhelmsruher Damm Ecke/ Senftenberger Ring, 13439 Berlin",
+        "telephone": "01723162525",
+        "details_url": null,
+        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 11:00-16:00; Tu 07:00-19:00; Sa 07:00-19:00; Th 07:00-19:00; We 07:00-19:00",
+        "title": "Testzentrum Märkische Zeile",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4684654405459,
+          52.5114059166474
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Oderstr. 8, 10247 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Su 09:00-20:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
+        "title": "TEST AREA Berlin",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.1645876,
+          52.550813
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Hauskavelweg 19, 13589 Berlin",
+        "telephone": "03055460971",
+        "details_url": "http://antigentest-spekte-spandauerfalkensee.buerger-schnelltest.de",
+        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 10:00-19:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
+        "title": "Bürgertest Hauskavelweg",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.1546174,
+          52.5494248
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Falkenseer Chaussee 199, 13589 Berlin",
+        "telephone": "03055460971",
+        "details_url": "http://antigentest-spekte-spandauerfalkensee.buerger-schnelltest.de",
+        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 10:00-19:00; Tu 07:00-20:00; Sa 07:00-20:00; Th 07:00-20:00; We 07:00-20:00",
+        "title": "Bürgertest Kiesteich",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.27774,
+          52.57575
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Bernauer Straße 132A, 13507 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 09:00-15:00; Mo 09:00-18:00; Tu 11:00-19:00; Sa 09:00-16:00; Th 09:00-18:00; We 09:00-15:00",
+        "title": "Zahnarztpraxis Michael Fuchs",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.323290998215,
+          52.4440715910166
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Hindenburgdamm 30, 12203 Berlin",
+        "telephone": null,
+        "details_url": "https://coronatest.de",
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "coronatest.de Charité Campus Benjamin Franklin",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3807,
+          52.55178
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Pankstraße 49, 13357 Berlin",
+        "telephone": "0174 478 5650",
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 11:00-16:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Testzentrum Wedding AZ",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.5354744,
+          52.5464429
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Boxberger Str. 3, 12681 Berlin",
+        "telephone": "017641579854",
+        "details_url": null,
+        "opening_hours": null,
+        "title": "AbrazDream-Mobile-Teststation",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.34554,
+          52.55422
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Müllerstraße 58, 13349 Berlin",
+        "telephone": null,
+        "details_url": "https://shop.pga.berlin",
+        "opening_hours": null,
+        "title": "Paul Gerhardt Apotheke Testzentrum",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: notwendig"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3893027,
+          52.5136032
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Friedrichstraße 176, 10117 Berlin",
+        "telephone": "(030) 224 347 38",
+        "details_url": "http://www.armmed.berlin",
+        "opening_hours": "Fr 07:30-19:30; Mo 07:30-19:30; Su 09:00-18:00; Tu 07:30-19:30; Sa 09:00-18:00; Th 07:30-19:30; We 07:30-19:30",
+        "title": "Arm-Med Berlin Corona Testcenter",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3532324,
+          52.5494426
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Müllerstraße 138D, 13353 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Testzentrum Müller",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4432293518146,
+          52.5003208383499
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schlesische Straße 6, 10997 Berlin",
+        "telephone": "+49 30 69 80 70 50",
+        "details_url": null,
+        "opening_hours": null,
+        "title": "Haarspree Test-to-Go",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3491751270544,
+          52.5317407915299
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Perleberger Str. 53, 10559 Berlin",
+        "telephone": "017672903307",
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Teststation",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.34163,
+          52.55674
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Müllerstr. 68, 13349 Berlin",
+        "telephone": "017655856284",
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 10:00-19:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "T.J Firstclass Teststation",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.43477,
+          52.5228
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Friedenstraße 97, 10249 Berlin",
+        "telephone": "017675271980",
+        "details_url": "http://www.border-point.de",
+        "opening_hours": "Fr 06:00-22:00; Mo 06:00-22:00; Su 06:00-22:00; Tu 06:00-22:00; Sa 06:00-22:00; Th 06:00-22:00; We 06:00-22:00",
+        "title": "Corona Border Point",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3329959405466,
+          52.5276447966733
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Emdener Str. 58, 10551 Berlin",
+        "telephone": "017 85 039 430",
+        "details_url": null,
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Moabit Teststelle",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.27538,
+          52.43966
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Berliner Straße 67, 14169 Berlin",
+        "telephone": null,
+        "details_url": "https://smarttest-berlin.de",
+        "opening_hours": "Fr 09:00-13:00, 14:00-18:00; Mo 09:00-13:00, 14:00-18:00; Su 09:00-13:00, 14:00-18:00; Tu 09:00-13:00, 14:00-18:00; Sa 09:00-13:00, 14:00-18:00; Th 09:00-13:00, 14:00-18:00; We 09:00-13:00, 14:00-18:00",
+        "title": "Smarttest67",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4342,
+          52.49965
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Skalitzer Straße 52, 10997 Berlin",
+        "telephone": null,
+        "details_url": "https://teststation2go@gmail.com",
+        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Tu 09:00-19:00; Sa 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
+        "title": "Teststation 2 Go",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4123749,
+          52.519849
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Grunerstraße 20, Grunerstraße 20 Berlin",
+        "telephone": "030/34336739",
+        "details_url": "http://www.soforttester.de",
+        "opening_hours": "Fr 08:00-22:00; Mo 08:00-22:00; Tu 08:00-22:00; Sa 08:00-22:00; Th 08:00-22:00; We 08:00-22:00",
+        "title": "Testzentrum im ALEXA",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3685409117116,
+          52.5490548083086
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Reinickendorfer Straße 91b, 13347 Berlin",
+        "telephone": "017656384520",
+        "details_url": null,
+        "opening_hours": "Fr 07:00-23:00; Mo 07:00-23:00; Su 07:00-23:00; Tu 07:00-23:00; Sa 07:00-23:00; Th 07:00-23:00; We 07:00-23:00",
+        "title": "Test-To-Go Lounge",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.420216,
+          52.516818
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schillingstraße 1A, 10179 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Su 07:00-21:00; Tu 07:00-21:00; Sa 07:00-21:00; Th 07:00-21:00; We 07:00-21:00",
+        "title": "COVID-Schnelltestzentrum",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4322987,
+          52.4820379
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Karl-Marx-Straße 66, 12043 Berlin",
+        "telephone": "+49202-94703195",
+        "details_url": "https://app.no-q.info/neukoelln-arcarden/checkins#",
+        "opening_hours": "Fr 09:00-20:00; Mo 09:00-20:00; Su 09:00-20:00; Tu 09:00-20:00; Sa 09:00-20:00; Th 09:00-20:00; We 09:00-20:00",
+        "title": "Corona Testcenter Neukölln Arkarden",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.379317,
+          52.567714
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Provinzstr. 40, 13409 Berlin",
+        "telephone": "03056828838",
+        "details_url": "http://www.xn--testzentrum-neuklln-56b.de/partner/provinzstr",
+        "opening_hours": "Fr 18:00-21:00; Mo 18:00-21:00; Su 18:00-21:00; Tu 18:00-21:00; Sa 18:00-21:00; Th 18:00-21:00; We 18:00-21:00",
+        "title": "Testzentrum Schönholz",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.485187,
+          52.502887
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Lückstr. 6, 10317 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 07:00-17:00; Mo 07:00-17:00; Su 10:00-17:00; Tu 07:00-17:00; Sa 07:00-17:00; Th 07:00-17:00; We 07:00-17:00",
+        "title": "Test to know Teststation",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.476251,
+          52.502605
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Türrschmidtstraße 2A, 10317 Berlin",
+        "telephone": null,
+        "details_url": "https://www.bmut.de/corona-testzentrum-rummelsburg-lichtenberg",
+        "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 09:00-20:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
+        "title": "BMUT Testzentrum",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.486208,
+          52.52417
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Vulkanstraße 3, 10367 Berlin",
+        "telephone": null,
+        "details_url": "https://www.bmut.de/corona-testzentrum-squash-house",
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 09:00-20:00; Tu 08:00-18:00; Sa 09:00-20:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "BMUT Testzentrum II",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.590432,
+          52.52085
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Cecilienplatz 9, 12619 Berlin",
+        "telephone": "+4915171331350",
+        "details_url": "https://norona-berlin.covidservicepoint.de",
+        "opening_hours": "Fr 10:00-20:00; Mo 10:00-20:00; Su 10:00-20:00; Tu 10:00-20:00; Sa 10:00-20:00; Th 10:00-20:00; We 10:00-20:00",
+        "title": "Norona-Hellersdorf",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.624721,
+          52.4482
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Bölschestr. 11, 12587 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 06:30-14:00, 16:00-20:30; Mo 06:30-14:00, 16:00-20:30; Su 06:30-14:00, 16:00-20:30; Tu 06:30-14:00, 16:00-20:30; Sa 06:30-14:00, 16:00-20:30; Th 06:30-14:00, 16:00-20:30; We 06:30-14:00, 16:00-20:30",
+        "title": "Teststelle Friedrichshagen",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.40105,
+          52.5155
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schlossplatz 1, 10178 Berlin",
+        "telephone": "01515 7120582",
+        "details_url": "http://www.schnelltests-berlin.com",
+        "opening_hours": "Fr 07:30-16:30; Mo 07:30-16:30; Tu 07:30-16:30; Th 07:30-16:30; We 07:30-16:30",
+        "title": "BG ESMT",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3877851000682,
+          52.4920575021479
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Mehringdamm 47, 10961 Berlin",
+        "telephone": "03023993827",
+        "details_url": null,
+        "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 09:00-22:00; Tu 07:00-22:00; Sa 09:00-22:00; Th 07:00-22:00; We 07:00-22:00",
+        "title": "COVID-Teststation Orti",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.508376,
+          52.543038
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Ferdinand-Schultze-Str. 93, 13055 Berlin",
+        "telephone": "03085749858",
+        "details_url": "https://testcenter-ost.de",
+        "opening_hours": "Fr 07:00-18:00; Mo 07:00-18:00; Su 07:00-18:00; Tu 07:00-18:00; Sa 07:00-18:00; Th 07:00-18:00; We 07:00-18:00",
+        "title": "Testcenter OST",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3982306,
+          52.5063482
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Oranienstr. 106, 10696 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": null,
+        "title": "Test-Center (SenWGPG, Test)",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: notwendig"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.2926213847253,
+          52.5106042125203
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Kaiserdamm 110, 14057 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-23:00; Mo 08:00-23:00; Su 08:00-23:00; Tu 08:00-23:00; Sa 08:00-23:00; Th 08:00-23:00; We 08:00-23:00",
+        "title": "Moodstestung",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3556712,
+          52.5594196
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schwyzer Straße 28c, 13349 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Su 12:00-18:00; Sa 12:00-18:00",
+        "title": "CoronaTest65Mobil",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.43004,
+          52.48514
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Donaustraße 130, 12043 Berlin",
+        "telephone": null,
+        "details_url": "https://dieteststation.de",
+        "opening_hours": "Fr 09:00-19:00; Mo 09:00-19:00; Su 09:00-19:00; Tu 09:00-19:00; Sa 09:00-19:00; Th 09:00-19:00; We 09:00-19:00",
+        "title": "dieTeststation - Donaustr.",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4577884,
+          52.5278956
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Landsberger Allee 116, 10369 Berlin",
+        "telephone": null,
+        "details_url": "https://schnelltestberlin.de/lichtenberg",
+        "opening_hours": "Fr 08:00-20:00; Mo 08:00-20:00; Su 08:00-20:00; Tu 08:00-20:00; Sa 08:00-20:00; Th 08:00-20:00; We 08:00-20:00",
+        "title": "Schnelltest Berlin Lichtenberg",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.2799045982178,
+          52.5148540657192
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Königin-Elisabeth-Straße 47A, 14059 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 07:00-19:00; Tu 07:00-19:00; Sa 07:00-19:00; Th 07:00-19:00; We 07:00-19:00",
+        "title": "M.S. Teststation",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.42938,
+          52.533546
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Greifswalder Str. 204, 10405 Berlin",
+        "telephone": null,
+        "details_url": "https://www.BSC-testzentrum.de",
+        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Su 07:00-21:00; Tu 07:00-21:00; Sa 07:00-21:00; Th 07:00-21:00; We 07:00-21:00",
+        "title": "BSC Testzentrum",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4832136120222,
+          52.6123943151532
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Alt-Karow 8, 13125 Berlin",
+        "telephone": "017660499632",
+        "details_url": "http://www.testzentrumaltkarow.de",
+        "opening_hours": "Fr 09:00-15:00, 18:30-20:00; Mo 09:00-15:00, 18:30-20:00; Su 14:00-18:00; Tu 09:00-15:00, 18:30-20:00; Th 09:00-15:00, 18:30-20:00; We 09:00-15:00, 18:30-20:00",
+        "title": "Testzentrum Alt-Karow",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3044464,
+          52.5158629
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Wilmersdorfer Straße 16, 10585 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 08:00-18:00; Mo 08:00-18:00; Su 08:00-18:00; Tu 08:00-18:00; Sa 08:00-18:00; Th 08:00-18:00; We 08:00-18:00",
+        "title": "City Corona Wilmersdorfer Straße",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4537479,
+          52.5162617
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Frankfurter Allee 5, 10247 Berlin",
+        "telephone": null,
+        "details_url": "https://www.coronatest-frankfurterallee5.de",
+        "opening_hours": "Fr 07:00-20:00; Mo 07:00-20:00; Su 10:00-20:00; Tu 07:00-20:00; Sa 08:00-22:00; Th 07:00-20:00; We 07:00-20:00",
+        "title": "Coronatest Frankfurter Tor",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.46718,
+          52.51473
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Frankfurter Allee 67, 10247 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 07:00-21:00; Mo 07:00-21:00; Su 07:00-21:00; Tu 07:00-21:00; Sa 07:00-21:00; Th 07:00-21:00; We 07:00-21:00",
+        "title": "Testzentrum Frankfurter Allee",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.4645,
+          52.5151
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Samariterstraße 40, 10247 Berlin",
+        "telephone": null,
+        "details_url": "https://www.covid19center.de/samariterstrasse",
+        "opening_hours": "Fr 07:00-22:00; Mo 07:00-22:00; Su 07:00-22:00; Tu 07:00-22:00; Sa 07:00-22:00; Th 07:00-22:00; We 07:00-22:00",
+        "title": "Corona Testzentrum Samariterstraße",
+        "hints": [
+          "PCR-Nachtestung: ja",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: ja",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.3933768,
+          52.4921372
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Gneisenaustraße 95, 10961 Berlin",
+        "telephone": null,
+        "details_url": null,
+        "opening_hours": "Fr 07:00-19:00; Mo 07:00-19:00; Su 08:00-19:00; Tu 07:00-19:00; Sa 08:00-19:00; Th 07:00-19:00; We 07:00-19:00",
+        "title": "Testzentrum in Gneisenau",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: keine Angabe",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: optional"
+        ]
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          13.41395,
+          52.55165
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "location": "Schönhauser Allee 108, 10439 Berlin",
+        "telephone": null,
+        "details_url": "https://www.aprtestzentrum.de",
+        "opening_hours": null,
+        "title": "APR Testzentrum",
+        "hints": [
+          "PCR-Nachtestung: keine Angabe",
+          "Barrierefreiheit: ja",
+          "Tests für Kinder: keine Angabe",
+          "Terminbuchung: nicht notwendig"
+        ],
+        "opening_hours_unclassified": "Keine Angabe"
       },
       "type": "Feature"
     }

--- a/preprocessing/berlin/compile-berlin-geojson.js
+++ b/preprocessing/berlin/compile-berlin-geojson.js
@@ -140,6 +140,14 @@ const convertToGeoJson = (node) => {
         json.geometry.coordinates[0] = 13.3667143;
         json.geometry.coordinates[1] = 52.5500701;
     }
+    if ("Coronatest Frankfurter Tor" === json.properties.title) {
+        json.geometry.coordinates[0] = 13.4537479;
+        json.geometry.coordinates[1] = 52.5162617;
+    }
+    if ("Testzentrum im ALEXA" === json.properties.title) {
+        json.geometry.coordinates[0] = 13.4123749;
+        json.geometry.coordinates[1] = 52.519849;
+    }
     return json;
 };
 


### PR DESCRIPTION
+ Manually fix coordinates for "Testzentrum im ALEXA" and "Coronatest Frankfurter Tor".